### PR TITLE
Defer creating the binding graph in a builder

### DIFF
--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -46,8 +46,6 @@ public final class IntegrationTest {
   }
 
   @Test public void bindsInstanceCalledTwice() {
-    ignoreReflectionBackend();
-
     InstanceBinding component = backend.builder(InstanceBinding.Builder.class)
         .string("foo")
         .string("bar")

--- a/reflect/src/main/java/dagger/reflect/DaggerReflect.java
+++ b/reflect/src/main/java/dagger/reflect/DaggerReflect.java
@@ -95,11 +95,8 @@ public final class DaggerReflect {
     Set<Class<?>> dependencies = new LinkedHashSet<>();
     Collections.addAll(dependencies, component.dependencies());
 
-    BindingGraph.Builder graphBuilder = new BindingGraph.Builder()
-        .justInTimeProvider(new ReflectiveJustInTimeProvider());
-
-    return ComponentBuilderInvocationHandler.create(componentClass, builderClass, graphBuilder,
-        modules, dependencies);
+    return ComponentBuilderInvocationHandler.create(componentClass, builderClass, modules,
+        dependencies);
   }
 
   static RuntimeException notImplemented(String feature) {

--- a/reflect/src/test/java/dagger/reflect/ComponentBuilderInvocationHandlerTest.java
+++ b/reflect/src/test/java/dagger/reflect/ComponentBuilderInvocationHandlerTest.java
@@ -34,7 +34,7 @@ public final class ComponentBuilderInvocationHandlerTest {
   @Test public void undeclaredModule() {
     UndeclaredModules.Builder builder =
         ComponentBuilderInvocationHandler.create(UndeclaredModules.class,
-            UndeclaredModules.Builder.class, new BindingGraph.Builder(), emptySet(), emptySet());
+            UndeclaredModules.Builder.class, emptySet(), emptySet());
     try {
       builder.module(new UndeclaredModules.Module1());
       fail();
@@ -52,8 +52,7 @@ public final class ComponentBuilderInvocationHandlerTest {
   @Test public void undeclaredDependencies() {
     UndeclaredDependencies.Builder builder =
         ComponentBuilderInvocationHandler.create(UndeclaredDependencies.class,
-            UndeclaredDependencies.Builder.class, new BindingGraph.Builder(), emptySet(),
-            emptySet());
+            UndeclaredDependencies.Builder.class, emptySet(), emptySet());
     try {
       builder.dep("hey");
       fail();


### PR DESCRIPTION
Because you can call builder methods multiple times, defer creating the binding graph until you call the create method. The binding graph is much more strict about overwriting and re-using a builder to create multiple component instances probably led to accidental shared state.