### PR TITLE
Cleanup: rawtypes, unchecked, NullAway, errorprone and some inspections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,5 +65,15 @@ subprojects {
       check("JavaxInjectOnAbstractMethod", CheckSeverity.OFF)
       option("NullAway:AnnotatedPackages", "dagger.reflect")
     }
+    options.setCompilerArgs(options.getCompilerArgs() + [
+        // strict compilation, treat all warnings as errors, including errorprone
+        '-Werror',
+        // enable all warnings
+        '-Xlint:all',
+        // hide warning: No processor claimed any of these annotations: dagger.*,org.junit.Test
+        '-Xlint:-processing',
+        // hide warning: MethodParameters attribute introduced in version 52.0 class files is ignored in version 51.0 class files
+        '-Xlint:-classfile'
+    ])
   }
 }

--- a/codegen/src/main/java/dagger/internal/DaggerCodegen.java
+++ b/codegen/src/main/java/dagger/internal/DaggerCodegen.java
@@ -23,7 +23,7 @@ public final class DaggerCodegen {
     return invokeStatic(findImplementationClass(componentClass), "create", componentClass);
   }
 
-  public static <C, B> B builder(Class<B> builderClass) {
+  public static <B> B builder(Class<B> builderClass) {
     Class<?> componentClass = builderClass.getEnclosingClass();
     if (componentClass == null) {
       throw new IllegalArgumentException(builderClass.getCanonicalName()

--- a/codegen/src/main/java/dagger/internal/DaggerCodegen.java
+++ b/codegen/src/main/java/dagger/internal/DaggerCodegen.java
@@ -32,6 +32,7 @@ public final class DaggerCodegen {
     return invokeStatic(findImplementationClass(componentClass), "builder", builderClass);
   }
 
+  @SuppressWarnings("unchecked")
   private static <C> Class<? extends C> findImplementationClass(Class<C> componentClass) {
     String implementationName =
         componentClass.getPackage().getName() + ".Dagger" + componentClass.getSimpleName();

--- a/integration-tests/src/main/java/com/example/BindsProviderNull.java
+++ b/integration-tests/src/main/java/com/example/BindsProviderNull.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import dagger.Binds;
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import org.jetbrains.annotations.Nullable;
+
+@Component(modules = BindsProviderNull.Module1.class)
+interface BindsProviderNull {
+
+  @Nullable CharSequence string();
+
+  @Module
+  abstract class Module1 {
+    @Provides static @Nullable String string() {
+      return null;
+    }
+    @Binds abstract CharSequence charSequence(@Nullable String foo);
+  }
+}

--- a/integration-tests/src/main/java/com/example/ComponentProviderNull.java
+++ b/integration-tests/src/main/java/com/example/ComponentProviderNull.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import org.jetbrains.annotations.Nullable;
+
+@Component(modules = ComponentProviderNull.Module1.class)
+interface ComponentProviderNull {
+
+  @Nullable String string();
+
+  @Module
+  abstract class Module1 {
+    @Provides static @Nullable String string() {
+      return null;
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -40,7 +40,7 @@ public final class IntegrationTest {
 
   @Test public void bindsProvider() {
     BindsProvider component = backend.create(BindsProvider.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat((String) component.string()).isEqualTo("foo");
   }
 
   @Test public void bindIntoSet() {
@@ -347,18 +347,18 @@ public final class IntegrationTest {
   @Test public void moduleClassAndInterfaceHierarchy() {
     ModuleClassAndInterfaceHierarchy component =
         backend.create(ModuleClassAndInterfaceHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat((String) component.string()).isEqualTo("foo");
   }
 
   @Test public void moduleClassAndInterfaceDuplicatesHierarchy() {
     ModuleClassAndInterfaceDuplicatesHierarchy component =
         backend.create(ModuleClassAndInterfaceDuplicatesHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat((String) component.string()).isEqualTo("foo");
   }
 
   @Test public void moduleClassHierarchy() {
     ModuleClassHierarchy component = backend.create(ModuleClassHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat((String) component.string()).isEqualTo("foo");
   }
 
   @Test public void moduleClassHierarchyStatics() {
@@ -368,12 +368,12 @@ public final class IntegrationTest {
 
   @Test public void moduleInterface() {
     ModuleInterface component = backend.create(ModuleInterface.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat((String) component.string()).isEqualTo("foo");
   }
 
   @Test public void moduleInterfaceHierarchy() {
     ModuleInterface component = backend.create(ModuleInterface.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat((String) component.string()).isEqualTo("foo");
   }
 
   private void ignoreReflectionBackend() {

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -28,6 +28,11 @@ public final class IntegrationTest {
     assertThat(component.string()).isEqualTo("foo");
   }
 
+  @Test public void componentProviderNull() {
+    ComponentProviderNull component = backend.create(ComponentProviderNull.class);
+    assertThat(component.string()).isNull();
+  }
+
   @Test public void componentProviderQualified() {
     ComponentProviderQualified component = backend.create(ComponentProviderQualified.class);
     assertThat(component.string()).isEqualTo("foo");
@@ -41,6 +46,11 @@ public final class IntegrationTest {
   @Test public void bindsProvider() {
     BindsProvider component = backend.create(BindsProvider.class);
     assertThat((String) component.string()).isEqualTo("foo");
+  }
+
+  @Test public void bindsProviderNull() {
+    BindsProviderNull component = backend.create(BindsProviderNull.class);
+    assertThat(component.string()).isNull();
   }
 
   @Test public void bindIntoSet() {

--- a/reflect-compiler/src/main/java/dagger/reflect/compiler/DaggerReflectCompiler.java
+++ b/reflect-compiler/src/main/java/dagger/reflect/compiler/DaggerReflectCompiler.java
@@ -87,7 +87,7 @@ public final class DaggerReflectCompiler extends AbstractProcessor {
     return false;
   }
 
-  private static @Nullable TypeElement findBuilder(TypeElement component) {
+  private static @Nullable TypeElement findBuilder(Element component) {
     for (Element enclosed : component.getEnclosedElements()) {
       if (enclosed.getAnnotation(Component.Builder.class) != null) {
         return (TypeElement) enclosed;

--- a/reflect/src/main/java/dagger/reflect/Binding.java
+++ b/reflect/src/main/java/dagger/reflect/Binding.java
@@ -182,7 +182,7 @@ interface Binding<T> extends Provider<T> {
       this.dependencies = dependencies;
     }
 
-    @Override public T get() {
+    @Override public @Nullable T get() {
       Object[] arguments = new Object[dependencies.length];
       for (int i = 0; i < arguments.length; i++) {
         arguments[i] = dependencies[i].get();

--- a/reflect/src/main/java/dagger/reflect/Binding.java
+++ b/reflect/src/main/java/dagger/reflect/Binding.java
@@ -92,6 +92,7 @@ interface Binding<T> extends Provider<T> {
       return new Key[] { dependency };
     }
 
+    @SuppressWarnings("unchecked")
     @Override public Binding<T> link(Binding<?>[] dependencies) {
       return (Binding<T>) dependencies[0];
     }
@@ -137,7 +138,9 @@ interface Binding<T> extends Provider<T> {
       if (dependency == null) {
         return Optional.empty();
       }
-      return Optional.of((T) dependency.get());
+      @SuppressWarnings("unchecked")
+      T value = (T) dependency.get();
+      return Optional.of(value);
     }
   }
 
@@ -184,7 +187,9 @@ interface Binding<T> extends Provider<T> {
       for (int i = 0; i < arguments.length; i++) {
         arguments[i] = dependencies[i].get();
       }
-      return (T) tryInvoke(instance, method, arguments);
+      @SuppressWarnings("unchecked") // the binding is associated with the return type of method as key
+      T value = (T) tryInvoke(instance, method, arguments);
+      return value;
     }
   }
 

--- a/reflect/src/main/java/dagger/reflect/BindingGraph.java
+++ b/reflect/src/main/java/dagger/reflect/BindingGraph.java
@@ -41,7 +41,7 @@ final class BindingGraph {
     chain.put(key, unlinked);
 
     Key[] dependencyKeys = unlinked.dependencies();
-    Binding<?>[] dependencies = new Binding[dependencyKeys.length];
+    Binding<?>[] dependencies = new Binding<?>[dependencyKeys.length];
 
     for (int i = 0; i < dependencyKeys.length; i++) {
       Key dependencyKey = dependencyKeys[i];

--- a/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
@@ -52,7 +52,7 @@ final class ComponentBuilderInvocationHandler implements InvocationHandler {
   private final Map<Class<?>, Object> dependencyInstances;
 
   private ComponentBuilderInvocationHandler(Class<?> componentClass, Class<?> builderClass,
-      Set<Class<?>> componentModules, Set<Class<?>> componentDependencies) {
+      Iterable<Class<?>> componentModules, Iterable<Class<?>> componentDependencies) {
     this.componentClass = componentClass;
     this.builderClass = builderClass;
     this.boundInstances = new LinkedHashMap<>();

--- a/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
@@ -40,7 +40,7 @@ final class ComponentBuilderInvocationHandler implements InvocationHandler {
           + " must be public in order to be reflectively created");
     }
     return builderClass.cast(
-        Proxy.newProxyInstance(builderClass.getClassLoader(), new Class[] { builderClass },
+        Proxy.newProxyInstance(builderClass.getClassLoader(), new Class<?>[] { builderClass },
             new ComponentBuilderInvocationHandler(componentClass, builderClass, modules,
                 dependencies)));
   }

--- a/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
@@ -29,7 +29,7 @@ import static dagger.reflect.Reflection.findQualifier;
 
 final class ComponentInvocationHandler implements InvocationHandler {
   static <T> T create(Class<T> cls, BindingGraph graph) {
-    return cls.cast(Proxy.newProxyInstance(cls.getClassLoader(), new Class[] { cls },
+    return cls.cast(Proxy.newProxyInstance(cls.getClassLoader(), new Class<?>[] { cls },
         new ComponentInvocationHandler(graph)));
   }
 
@@ -74,6 +74,7 @@ final class ComponentInvocationHandler implements InvocationHandler {
             "Members injection methods may only return the injected type or void: " + method);
       }
 
+      @SuppressWarnings({"unchecked", "RedundantCast"})
       MembersInjector<Object> injector =
           (MembersInjector<Object>) ReflectiveMembersInjector.create(parameterTypes[0], graph);
       return new MembersInjectorMethodInvocationHandler(injector, returnInstance);

--- a/reflect/src/main/java/dagger/reflect/Reflection.java
+++ b/reflect/src/main/java/dagger/reflect/Reflection.java
@@ -54,7 +54,7 @@ final class Reflection {
     return scope;
   }
 
-  static void trySet(@Nullable Object instance, Field field, Object value) {
+  static void trySet(@Nullable Object instance, Field field, @Nullable Object value) {
     if ((field.getModifiers() & Modifier.PUBLIC) == 0) {
       field.setAccessible(true);
     }

--- a/reflect/src/main/java/dagger/reflect/Reflection.java
+++ b/reflect/src/main/java/dagger/reflect/Reflection.java
@@ -65,8 +65,7 @@ final class Reflection {
     }
   }
 
-  @Nullable
-  static Object tryInvoke(@Nullable Object instance, Method method, Object... arguments) {
+  static @Nullable Object tryInvoke(@Nullable Object instance, Method method, Object... arguments) {
     if ((method.getModifiers() & Modifier.PUBLIC) == 0) {
       method.setAccessible(true);
     }

--- a/reflect/src/main/java/dagger/reflect/ReflectiveJustInTimeProvider.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveJustInTimeProvider.java
@@ -20,22 +20,25 @@ final class ReflectiveJustInTimeProvider implements BindingGraph.JustInTimeProvi
     if (!(type instanceof Class<?>)) {
       return null; // Parameterized/array types can't be just-in-time satisfied.
     }
-    Class<Object> cls = (Class<Object>) type;
+    return create((Class<?>) type);
+  }
 
+  private static <T> @Nullable Binding<T> create(Class<T> cls) {
     Annotation scope = findScope(cls.getAnnotations());
     if (scope != null) {
       throw notImplemented("Just-in-time scoped bindings");
     }
 
-    Constructor<?>[] constructors = cls.getDeclaredConstructors();
-    Constructor<Object> target = null;
-    for (Constructor<?> constructor : constructors) {
+    @SuppressWarnings("unchecked")
+    Constructor<T>[] constructors = (Constructor<T>[]) cls.getDeclaredConstructors();
+    Constructor<T> target = null;
+    for (Constructor<T> constructor : constructors) {
       if (constructor.getAnnotation(Inject.class) != null) {
         if (target != null) {
           throw new IllegalStateException(
               cls.getCanonicalName() + " defines multiple @Inject-annotations constructors");
         }
-        target = (Constructor<Object>) constructor;
+        target = constructor;
       }
     }
     if (target == null) {

--- a/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
@@ -75,8 +75,7 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
 
         Type[] parameterTypes = method.getGenericParameterTypes();
         Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-        @SuppressWarnings("rawtypes")
-        Binding<?>[] bindings = new Binding[parameterTypes.length];
+        Binding<?>[] bindings = new Binding<?>[parameterTypes.length];
         for (int i = 0; i < parameterTypes.length; i++) {
           Key key = Key.of(findQualifier(parameterAnnotations[i]), parameterTypes[i]);
           bindings[i] = graph.getBinding(key);

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -46,10 +46,10 @@ final class ReflectiveModuleParser {
         TypeWrapper wrapper = TypeWrapper.NONE;
         if ((method.getModifiers() & ABSTRACT) != 0) {
           if (method.getAnnotation(Binds.class) != null) {
-            binding = new Binding.UnlinkedBinds(method);
+            binding = new Binding.UnlinkedBinds<>(method);
           } else if (method.getAnnotation(BindsOptionalOf.class) != null) {
             wrapper = TypeWrapper.OPTIONAL;
-            binding = new Binding.UnlinkedOptionalBinding(method);
+            binding = new Binding.UnlinkedOptionalBinding<>(method);
           } else {
             continue;
           }
@@ -59,7 +59,7 @@ final class ReflectiveModuleParser {
           }
 
           if (method.getAnnotation(Provides.class) != null) {
-            binding = new Binding.UnlinkedProvides(instance, method);
+            binding = new Binding.UnlinkedProvides<>(instance, method);
           } else {
             continue;
           }

--- a/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
+++ b/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("ALL") // Unused fields/parameters and over-specified visibility for testing.
+@SuppressWarnings("unused") // Unused fields/parameters and over-specified visibility for testing.
 public final class ReflectiveMembersInjectorTest {
   private static class PrivateField {
     // [dagger-compiler] error: Dagger does not support injection into private fields
@@ -95,7 +95,7 @@ public final class ReflectiveMembersInjectorTest {
     }
   }
 
-  private static interface Interface {
+  private interface Interface {
     // [dagger-compile] Methods with @Inject may not be abstract
     @Inject void interfaceMethod(String one);
   }


### PR DESCRIPTION
The goal was 0 compile-time warnings, so new ones can be noticed easily and fixed.