### PR TITLE
Allow @Modules to be interfaces

### DIFF
--- a/integration-tests/src/main/java/com/example/BindsProviderAbstract.java
+++ b/integration-tests/src/main/java/com/example/BindsProviderAbstract.java
@@ -5,8 +5,8 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 
-@Component(modules = BindsProvider.Module1.class)
-interface BindsProvider {
+@Component(modules = BindsProviderAbstract.Module1.class)
+interface BindsProviderAbstract {
   CharSequence string();
 
   @Module

--- a/integration-tests/src/main/java/com/example/BindsProviderInterface.java
+++ b/integration-tests/src/main/java/com/example/BindsProviderInterface.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import dagger.Binds;
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = BindsProviderInterface.Module1.class)
+interface BindsProviderInterface {
+  CharSequence string();
+
+  @Module
+  interface Module1 {
+    @Provides static String string() {
+      return "foo";
+    }
+    @Binds CharSequence charSequence(String foo);
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -33,8 +33,13 @@ public final class IntegrationTest {
     assertThat(component.string()).isEqualTo("foo");
   }
 
-  @Test public void bindsProvider() {
-    BindsProvider component = backend.create(BindsProvider.class);
+  @Test public void bindsProviderAbstract() {
+    BindsProviderAbstract component = backend.create(BindsProviderAbstract.class);
+    assertThat(component.string()).isEqualTo("foo");
+  }
+
+  @Test public void bindsProviderInterface() {
+    BindsProviderInterface component = backend.create(BindsProviderInterface.class);
     assertThat(component.string()).isEqualTo("foo");
   }
 

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -22,7 +22,7 @@ final class ReflectiveModuleParser {
   static void parse(Class<?> moduleClass, @Nullable Object instance,
       BindingGraph.Builder graphBuilder) {
     Class<?> target = moduleClass;
-    while (target != Object.class) {
+    while (target != Object.class && target != null) {
       for (Method method : target.getDeclaredMethods()) {
         if ((method.getModifiers() & PRIVATE) != 0) {
           throw new IllegalArgumentException("Private module methods are not allowed: " + method);


### PR DESCRIPTION
> getSuperclass(): If this Class represents either the Object class, an interface, a primitive type, or void, then null is returned.