### PR TITLE
Allow injecting into empty abstract class and interface

### DIFF
--- a/integration-tests/src/main/java/com/example/MemberInjectionEmptyAbstract.java
+++ b/integration-tests/src/main/java/com/example/MemberInjectionEmptyAbstract.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import dagger.Component;
+
+@Component
+interface MemberInjectionEmptyAbstract {
+
+  void inject(Target target);
+
+  abstract class Target {
+  }
+}

--- a/integration-tests/src/main/java/com/example/MemberInjectionEmptyInterface.java
+++ b/integration-tests/src/main/java/com/example/MemberInjectionEmptyInterface.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import dagger.Component;
+
+@Component
+interface MemberInjectionEmptyInterface {
+
+  void inject(Target target);
+
+  interface Target {
+  }
+}

--- a/integration-tests/src/main/java/com/example/MemberInjectionInterface.java
+++ b/integration-tests/src/main/java/com/example/MemberInjectionInterface.java
@@ -1,0 +1,24 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = MemberInjectionInterface.Module1.class)
+interface MemberInjectionInterface {
+
+  void inject(Target target);
+
+  interface Target {
+    String FOO = "foo";
+
+    void method(String foo);
+  }
+
+  @Module
+  abstract class Module1 {
+    @Provides static String foo() {
+      return "foo";
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -176,9 +176,23 @@ public final class IntegrationTest {
     }
   }
 
-  @Test public void memberInjectionEmpty() {
+  @Test public void memberInjectionEmptyClass() {
     MemberInjectionEmpty component = backend.create(MemberInjectionEmpty.class);
     MemberInjectionEmpty.Target target = new MemberInjectionEmpty.Target();
+    component.inject(target);
+    // No state, nothing to verify, except it didn't throw.
+  }
+
+  @Test public void memberInjectionEmptyAbstractClass() {
+    MemberInjectionEmptyAbstract component = backend.create(MemberInjectionEmptyAbstract.class);
+    MemberInjectionEmptyAbstract.Target target = new MemberInjectionEmptyAbstract.Target() {};
+    component.inject(target);
+    // No state, nothing to verify, except it didn't throw.
+  }
+
+  @Test public void memberInjectionEmptyInterface() {
+    MemberInjectionEmptyInterface component = backend.create(MemberInjectionEmptyInterface.class);
+    MemberInjectionEmptyInterface.Target target = new MemberInjectionEmptyInterface.Target() {};
     component.inject(target);
     // No state, nothing to verify, except it didn't throw.
   }

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -197,6 +197,20 @@ public final class IntegrationTest {
     // No state, nothing to verify, except it didn't throw.
   }
 
+  @Test public void memberInjectionInterface() {
+    MemberInjectionInterface component = backend.create(MemberInjectionInterface.class);
+    class Target implements MemberInjectionInterface.Target {
+      boolean called;
+      @Override public void method(String foo) {
+        called = true;
+      }
+    }
+    Target target = new Target();
+    component.inject(target);
+
+    assertThat(target.called).isFalse();
+  }
+
   @Test public void memberInjectionReturnInstance() {
     MemberInjectionReturnInstance component = backend.create(MemberInjectionReturnInstance.class);
     MemberInjectionReturnInstance.Target in = new MemberInjectionReturnInstance.Target();

--- a/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
@@ -34,11 +34,9 @@ import static dagger.reflect.Reflection.trySet;
 
 final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
   static <T> MembersInjector<T> create(Class<T> cls, BindingGraph graph) {
-    // TODO throw if interface?
-
     Deque<ClassBindings> hierarchyBindings = new ArrayDeque<>();
     Class<?> target = cls;
-    while (target != Object.class) {
+    while (target != Object.class && target != null) {
       Map<Field, Provider<?>> fieldProviders = new LinkedHashMap<>();
       for (Field field : target.getDeclaredFields()) {
         if (field.getAnnotation(Inject.class) == null) {


### PR DESCRIPTION
Addressing https://github.com/JakeWharton/SdkSearch/pull/149#issuecomment-447603817

Same fix as https://github.com/JakeWharton/dagger-reflect/pull/13/files#diff-7b2e80eb160305e528b1087494445263R25, but no need to walk super-interfaces, just let it pass through the method.