### PR TITLE
Line up and test error messages in components/builders

### DIFF
--- a/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
@@ -126,19 +126,17 @@ final class ComponentBuilderInvocationHandler implements InvocationHandler {
             if (moduleInstances.containsKey(parameterClass)) {
               moduleInstances.put(parameterClass, args[0]);
             } else {
-              throw new IllegalStateException("Module "
-                  + parameterClass.getName()
-                  + " not declared in component "
-                  + componentClass.getName());
+              throw new IllegalStateException(
+                  "@Component.Builder has setters for modules or components that aren't required: "
+                      + "[" + method + "]");
             }
           } else {
             if (dependencyInstances.containsKey(parameterClass)) {
               dependencyInstances.put(parameterClass, args[0]);
             } else {
-              throw new IllegalStateException("Dependency on "
-                  + parameterClass.getName()
-                  + " not declared in component "
-                  + componentClass.getName());
+              throw new IllegalStateException(
+                  "@Component.Builder has setters for modules or components that aren't required: "
+                      + "[" + method + "]");
             }
           }
         } else {

--- a/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
@@ -68,7 +68,8 @@ final class ComponentInvocationHandler implements InvocationHandler {
       } else if (method.getReturnType().equals(parameterTypes[0])) {
         returnInstance = true;
       } else {
-        throw new IllegalStateException(); // TODO return type must be void or assignable
+        throw new IllegalStateException(
+            "Members injection methods may only return the injected type or void: " + method);
       }
 
       MembersInjector<Object> injector =


### PR DESCRIPTION
Not exactly the same message, but close. The method signature has `.` separators in dagger-compile and `$` separators in dagger-reflect.