### PR TITLE
Allow compilation on Java 9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
+  - openjdk11
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/reflect-compiler/build.gradle
+++ b/reflect-compiler/build.gradle
@@ -13,7 +13,9 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.truth
   testImplementation deps.compileTesting
-  testImplementation files(Jvm.current().getToolsJar())
+  if (!Jvm.current().javaVersion.isJava9Compatible()) {
+    testImplementation files(Jvm.current().getToolsJar())
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
Quick googling revealed that tools.jar was removed in Java 9, this PR was tested via `gradlew clean check jar` on
 * java-1.8.0_121-x64-jdk
 * java-9.0.1_11-x64-jdk
 * java-10.0.2-x64-jdk
 * java-11.0.2-x64-jdk

with the change: 8, 9, 10, 11 all produce the same successful Gradle output
without the change: 8 compiles, 9, 10, 11 produces the following Gradle configuration failure:
```
P:\projects\contrib\github-dagger2-reflect>gradlew -S

FAILURE: Build failed with an exception.

* Where:
Build file 'P:\projects\contrib\github-dagger2-reflect\reflect-compiler\build.gradle' line: 16

* What went wrong:
A problem occurred evaluating project ':reflect-compiler'.
> java.lang.NullPointerException (no error message)

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating project ':reflect-compiler'.
        ...
Caused by: java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:221)
        at java.base/java.util.Arrays$ArrayList.<init>(Arrays.java:4323)
        at java.base/java.util.Arrays.asList(Arrays.java:4310)
        at org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection.<init>(DefaultConfigurableFileCollection.java:51)
        at org.gradle.api.internal.file.DefaultFileOperations.configurableFiles(DefaultFileOperations.java:123)
        at org.gradle.groovy.scripts.DefaultScript.files(DefaultScript.java:163)
        at build_1ehmsp07ek39vo8l636fwodqy$_run_closure1.doCall(P:\projects\contrib\github-dagger2-reflect\reflect-compiler\build.gradle:16)
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:70)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:154)
        at org.gradle.util.ConfigureUtil.configure(ConfigureUtil.java:105)
        at org.gradle.api.internal.project.DefaultProject.dependencies(DefaultProject.java:1190)
        at build_1ehmsp07ek39vo8l636fwodqy.run(P:\projects\contrib\github-dagger2-reflect\reflect-compiler\build.gradle:5)
```

it seems that TreeScanner is included in normal classpath from Java 9 (jdk.compiler module) and doesn't produce this error while running tests:
```
java.lang.NoClassDefFoundError: com/sun/source/util/TreeScanner
	at com.google.testing.compile.JavaSourcesSubject$CompilationClause.parsesAs(JavaSourcesSubject.java:143)
	at com.google.testing.compile.JavaSourcesSubject.parsesAs(JavaSourcesSubject.java:103)
	at com.google.testing.compile.JavaSourcesSubject$GeneratedCompilationBuilder.generatesSources(JavaSourcesSubject.java:448)
	at dagger.reflect.compiler.DaggerReflectCompilerTest.simple(DaggerReflectCompilerTest.java:58)
```