### PR TITLE
Model optional keys during binding linking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
     options.errorprone {
       disableWarningsInGeneratedCode = true
       check("JavaxInjectOnAbstractMethod", CheckSeverity.OFF)
+      check("NullAway", CheckSeverity.ERROR)
       option("NullAway:AnnotatedPackages", "dagger.reflect")
     }
   }

--- a/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Provider;
 import org.jetbrains.annotations.Nullable;
 
 import static dagger.reflect.DaggerReflect.notImplemented;
@@ -86,8 +87,8 @@ final class ComponentInvocationHandler implements InvocationHandler {
       }
 
       Key key = Key.of(findQualifier(method.getDeclaredAnnotations()), returnType);
-      Binding<?> binding = graph.getBinding(key);
-      return new BindingMethodInvocationHandler(binding);
+      Provider<?> provider = graph.getProvider(key);
+      return new ProviderMethodInvocationHandler(provider);
     }
 
     throw new IllegalStateException(method.toString()); // TODO unsupported method shape
@@ -97,15 +98,15 @@ final class ComponentInvocationHandler implements InvocationHandler {
     @Nullable Object invoke(Object[] args);
   }
 
-  private static final class BindingMethodInvocationHandler implements MethodInvocationHandler {
-    private final Binding<?> binding;
+  private static final class ProviderMethodInvocationHandler implements MethodInvocationHandler {
+    private final Provider<?> provider;
 
-    BindingMethodInvocationHandler(Binding<?> binding) {
-      this.binding = binding;
+    ProviderMethodInvocationHandler(Provider<?> provider) {
+      this.provider = provider;
     }
 
     @Override public Object invoke(Object[] args) {
-      return binding.get();
+      return provider.get();
     }
   }
 

--- a/reflect/src/main/java/dagger/reflect/ReflectiveComponentParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveComponentParser.java
@@ -1,5 +1,6 @@
 package dagger.reflect;
 
+import dagger.reflect.Binding.LinkedBinding;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -12,7 +13,7 @@ import java.util.Set;
 import static dagger.reflect.Reflection.findQualifier;
 
 final class ReflectiveComponentParser {
-  private static final Binding<?>[] NO_BINDINGS = new Binding<?>[0];
+  private static final LinkedBinding<?>[] NO_BINDINGS = new LinkedBinding<?>[0];
 
   static void parse(Class<?> moduleClass, Object instance,
       BindingGraph.Builder graphBuilder) {
@@ -34,7 +35,7 @@ final class ReflectiveComponentParser {
         Type type = method.getGenericReturnType();
         Key key = Key.of(qualifier, type);
 
-        Binding<?> binding = new Binding.LinkedProvides<>(instance, method, NO_BINDINGS);
+        Binding binding = new Binding.LinkedProvides<>(instance, method, NO_BINDINGS);
 
         graphBuilder.add(key, binding);
       }

--- a/reflect/src/main/java/dagger/reflect/ReflectiveJustInTimeProvider.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveJustInTimeProvider.java
@@ -1,5 +1,6 @@
 package dagger.reflect;
 
+import dagger.reflect.Binding.UnlinkedBinding;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
@@ -10,7 +11,7 @@ import static dagger.reflect.DaggerReflect.notImplemented;
 import static dagger.reflect.Reflection.findScope;
 
 final class ReflectiveJustInTimeProvider implements BindingGraph.JustInTimeProvider {
-  @Override public @Nullable Binding<?> create(Key key) {
+  @Override public @Nullable UnlinkedBinding create(Key key) {
     Annotation qualifier = key.qualifier();
     if (qualifier != null) {
       return null; // Qualified types can't be just-in-time satisfied.

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -42,7 +42,7 @@ final class ReflectiveModuleParser {
           throw new IllegalArgumentException("Private module methods are not allowed: " + method);
         }
 
-        Binding<?> binding;
+        Binding binding;
         TypeWrapper wrapper = TypeWrapper.NONE;
         if ((method.getModifiers() & ABSTRACT) != 0) {
           if (method.getAnnotation(Binds.class) != null) {

--- a/reflect/src/test/java/dagger/reflect/BindingGraphTest.java
+++ b/reflect/src/test/java/dagger/reflect/BindingGraphTest.java
@@ -22,7 +22,7 @@ import static dagger.reflect.Annotations.named;
 import static org.junit.Assert.fail;
 
 public final class BindingGraphTest {
-  static class DummyBinding extends Binding.UnlinkedBinding<Object> {
+  static class DummyBinding extends Binding.UnlinkedBinding {
     private final Object value;
     private final Key[] dependencies;
 
@@ -31,11 +31,11 @@ public final class BindingGraphTest {
       this.dependencies = dependencies;
     }
 
-    @Override public Key[] dependencies() {
-      return dependencies;
+    @Override public LinkRequest request() {
+      return new LinkRequest(dependencies);
     }
 
-    @Override public Binding<Object> link(Binding<?>[] dependencies) {
+    @Override public LinkedBinding<?> link(LinkedBinding<?>[] dependencies) {
       return new Instance<>(value);
     }
 
@@ -54,7 +54,7 @@ public final class BindingGraphTest {
         .add(keyC, new DummyBinding("C", keyA))
         .build();
     try {
-      graph.getBinding(keyA);
+      graph.getProvider(keyA);
       fail();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessageThat().isEqualTo("Dependency cycle detected!\n"


### PR DESCRIPTION
This removes the need to special case optional bindings inside the graph. Instead, the unlinked optional binding can request its dependency key as being optional. Optional keys which are not found will be null in the linked binding array.

Mostly renames in the code. The only interesting bit is in Binding and BindingGraph.