### PR TITLE
Ignore Android's local.properties added by IDEA 2018.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 /.idea
 out/
+/local.properties
 
 # Gradle
 .gradle


### PR DESCRIPTION
My IDEA keeps re-creating this file, hoping to get rid of this annoyance.