### PR TITLE
Fix errorprone UndefinedEquals violations

### DIFF
--- a/integration-tests/src/main/java/com/example/BindsProvider.java
+++ b/integration-tests/src/main/java/com/example/BindsProvider.java
@@ -7,13 +7,13 @@ import dagger.Provides;
 
 @Component(modules = BindsProvider.Module1.class)
 interface BindsProvider {
-  CharSequence string();
+  Number number();
 
   @Module
   abstract class Module1 {
-    @Provides static String string() {
-      return "foo";
+    @Provides static Integer integer() {
+      return 42;
     }
-    @Binds abstract CharSequence charSequence(String foo);
+    @Binds abstract Number number(Integer num);
   }
 }

--- a/integration-tests/src/main/java/com/example/ModuleClassAndInterfaceDuplicatesHierarchy.java
+++ b/integration-tests/src/main/java/com/example/ModuleClassAndInterfaceDuplicatesHierarchy.java
@@ -7,7 +7,7 @@ import dagger.Provides;
 
 @Component(modules = ModuleClassAndInterfaceDuplicatesHierarchy.Module1.class)
 interface ModuleClassAndInterfaceDuplicatesHierarchy {
-  CharSequence string();
+  Number number();
 
   @Module
   abstract class Module1 extends BaseModule implements InterfaceModule {
@@ -15,13 +15,13 @@ interface ModuleClassAndInterfaceDuplicatesHierarchy {
 
   @Module
   abstract class BaseModule implements InterfaceModule {
-    @Provides static String string() {
-      return "foo";
+    @Provides static Integer integer() {
+      return 42;
     }
   }
 
   @Module
   interface InterfaceModule {
-    @Binds CharSequence charSequence(String foo);
+    @Binds Number number(Integer num);
   }
 }

--- a/integration-tests/src/main/java/com/example/ModuleClassAndInterfaceHierarchy.java
+++ b/integration-tests/src/main/java/com/example/ModuleClassAndInterfaceHierarchy.java
@@ -7,17 +7,17 @@ import dagger.Provides;
 
 @Component(modules = ModuleClassAndInterfaceHierarchy.Module1.class)
 interface ModuleClassAndInterfaceHierarchy {
-  CharSequence string();
+  Number number();
 
   @Module
   abstract class Module1 implements BaseModule {
-    @Provides static String string() {
-      return "foo";
+    @Provides static Integer integer() {
+      return 42;
     }
   }
 
   @Module
   interface BaseModule {
-    @Binds CharSequence charSequence(String foo);
+    @Binds Number number(Integer num);
   }
 }

--- a/integration-tests/src/main/java/com/example/ModuleClassHierarchy.java
+++ b/integration-tests/src/main/java/com/example/ModuleClassHierarchy.java
@@ -7,17 +7,17 @@ import dagger.Provides;
 
 @Component(modules = ModuleClassHierarchy.Module1.class)
 interface ModuleClassHierarchy {
-  CharSequence string();
+  Number number();
 
   @Module
   abstract class Module1 extends BaseModule {
-    @Provides static String string() {
-      return "foo";
+    @Provides static Integer integer() {
+      return 42;
     }
   }
 
   @Module
   abstract class BaseModule {
-    @Binds abstract CharSequence charSequence(String foo);
+    @Binds abstract Number number(Integer num);
   }
 }

--- a/integration-tests/src/main/java/com/example/ModuleInterface.java
+++ b/integration-tests/src/main/java/com/example/ModuleInterface.java
@@ -7,14 +7,14 @@ import dagger.Provides;
 
 @Component(modules = ModuleInterface.Module1.class)
 interface ModuleInterface {
-  CharSequence string();
+  Number number();
 
   @Module
   interface Module1 {
-    @Provides static String string() {
-      return "foo";
+    @Provides static Integer integer() {
+      return 42;
     }
 
-    @Binds CharSequence charSequence(String foo);
+    @Binds Number number(Integer num);
   }
 }

--- a/integration-tests/src/main/java/com/example/ModuleInterfaceHierarchy.java
+++ b/integration-tests/src/main/java/com/example/ModuleInterfaceHierarchy.java
@@ -7,17 +7,17 @@ import dagger.Provides;
 
 @Component(modules = ModuleInterfaceHierarchy.Module1.class)
 interface ModuleInterfaceHierarchy {
-  CharSequence string();
+  Number number();
 
   @Module
   interface Module1 extends BaseModule {
-    @Provides static String string() {
-      return "foo";
+    @Provides static Integer integer() {
+      return 42;
     }
   }
 
   @Module
   interface BaseModule {
-    @Binds CharSequence charSequence(String foo);
+    @Binds Number number(Integer num);
   }
 }

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -45,7 +45,7 @@ public final class IntegrationTest {
 
   @Test public void bindsProvider() {
     BindsProvider component = backend.create(BindsProvider.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.number()).isEqualTo(42);
   }
 
   @Test public void bindsProviderNull() {
@@ -415,18 +415,18 @@ public final class IntegrationTest {
   @Test public void moduleClassAndInterfaceHierarchy() {
     ModuleClassAndInterfaceHierarchy component =
         backend.create(ModuleClassAndInterfaceHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.number()).isEqualTo(42);
   }
 
   @Test public void moduleClassAndInterfaceDuplicatesHierarchy() {
     ModuleClassAndInterfaceDuplicatesHierarchy component =
         backend.create(ModuleClassAndInterfaceDuplicatesHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.number()).isEqualTo(42);
   }
 
   @Test public void moduleClassHierarchy() {
     ModuleClassHierarchy component = backend.create(ModuleClassHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.number()).isEqualTo(42);
   }
 
   @Test public void moduleClassHierarchyStatics() {
@@ -436,12 +436,12 @@ public final class IntegrationTest {
 
   @Test public void moduleInterface() {
     ModuleInterface component = backend.create(ModuleInterface.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.number()).isEqualTo(42);
   }
 
   @Test public void moduleInterfaceHierarchy() {
     ModuleInterfaceHierarchy component = backend.create(ModuleInterfaceHierarchy.class);
-    assertThat(component.string()).isEqualTo("foo");
+    assertThat(component.number()).isEqualTo(42);
   }
 
   @Test public void nestedComponent() {


### PR DESCRIPTION
```
@SuppressWarnings("UndefinedEquals") // comparing `@Binds CharSequence provided(String)` to `String`
```
could be an alternative solution, but then other newer violations may be hidden and actually give a false-positive pass

The current PR approach of adding a cast is good both ways:
 * if it's unnecessary IDEA's `RedundantCast` kicks in
 * if cast is not there `UndefinedEquals` shows up again