### PR TITLE
Enable parallel build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+# Build Properties
 GROUP=com.jakewharton.dagger
 VERSION_NAME=0.1.0-SNAPSHOT
 
@@ -14,3 +15,6 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=jakewharton
 POM_DEVELOPER_NAME=Jake Wharton
+
+# Build Configuration
+org.gradle.parallel=true


### PR DESCRIPTION
Measurement: `gradlew clean check`
Current `master`: 16s (https://scans.gradle.com/s/im3x27mkieat6)
Gradle parallel: 10s (https://scans.gradle.com/s/xbixn2tzo6va4)

I like playing with builds, so I tried to go further:
Move APT classes to modules: 7s (https://scans.gradle.com/s/vutaiobangdts)
Move IntegrationTest next to classes: 6s (https://scans.gradle.com/s/5wiwkyulfkuy2)

The last two steps are not included in this PR, but the commits are here:
https://github.com/TWiStErRob/dagger-reflect/commits/abandoned/parallel
if you think it would be useful, happy to clean it up and raise a PR

Mind you I have a brand new PC with 14 cores, dagger-reflect builds use 4-8 cores only, so YMMV significantly.

Also tried https://guides.gradle.org/performance/#parallel_test_execution, but makes no difference with current amount of tests, compilation is the slowest.

Also tried `-Adagger.formatGeneratedSource=disabled` but makes no difference