### PR TITLE
Make unrelated methods have less of an effect on Modules

### DIFF
--- a/integration-tests/src/main/java/com/example/ImplicitModuleInstanceCannotBeCreated.java
+++ b/integration-tests/src/main/java/com/example/ImplicitModuleInstanceCannotBeCreated.java
@@ -1,0 +1,26 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = ImplicitModuleInstanceCannotBeCreated.Module1.class)
+public interface ImplicitModuleInstanceCannotBeCreated {
+
+  String string();
+
+  @Module
+  class Module1 {
+
+    Module1() {
+      throw new IllegalStateException("No need to instantiate this");
+    }
+
+    @Provides
+    static String string() {
+      return "one";
+    }
+
+    void justAnInstanceMethod() {}
+  }
+}

--- a/integration-tests/src/main/java/com/example/ModuleInterfaceDefaultMethodUnrelated.java
+++ b/integration-tests/src/main/java/com/example/ModuleInterfaceDefaultMethodUnrelated.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = ModuleInterfaceDefaultMethodUnrelated.Module1.class)
+interface ModuleInterfaceDefaultMethodUnrelated {
+
+  String string();
+
+  @Module
+  interface Module1 extends DefaultMethod {
+    @Provides
+    static String string() {
+      return "foo";
+    }
+
+    default void unrelatedMethod() {}
+  }
+
+  interface DefaultMethod {
+    default void unrelatedMethodInherited() {}
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -358,6 +358,14 @@ public final class IntegrationTest {
   }
 
   @Test
+  public void implicitModuleInstanceNotCreatedWhenUnnecessary() {
+    ImplicitModuleInstanceCannotBeCreated component =
+        backend.create(ImplicitModuleInstanceCannotBeCreated.class);
+
+    assertThat(component.string()).isEqualTo("one");
+  }
+
+  @Test
   public void builderBindsInstance() {
     BuilderBindsInstance component =
         backend.builder(BuilderBindsInstance.Builder.class).string("foo").build();
@@ -923,6 +931,41 @@ public final class IntegrationTest {
   public void moduleInterfaceHierarchy() {
     ModuleInterfaceHierarchy component = backend.create(ModuleInterfaceHierarchy.class);
     assertThat(component.number()).isEqualTo(42);
+  }
+
+  @Test
+  public void moduleInterfaceWithDefaultMethodUnrelatedDoesNotAffectDagger() {
+    ModuleInterfaceDefaultMethodUnrelated component =
+        backend.create(ModuleInterfaceDefaultMethodUnrelated.class);
+    assertThat(component.string()).isEqualTo("foo");
+  }
+
+  @Test
+  @IgnoreCodegen
+  public void moduleAbstractClassInstanceMethodNotAllowed() {
+    try {
+      backend.create(ModuleAbstractInstanceProvidesMethod.class);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "com.example.ModuleAbstractInstanceProvidesMethod.Module1 is abstract and has instance @Provides methods. Consider making the methods static or including a non-abstract subclass of the module instead.");
+    }
+  }
+
+  @Test
+  @IgnoreCodegen
+  public void moduleInterfaceWithDefaultMethodNotAllowed() {
+    try {
+      backend.create(ModuleInterfaceDefaultProvidesMethod.class);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "com.example.ModuleInterfaceDefaultProvidesMethod.Module1 is abstract and has instance @Provides methods. Consider making the methods static or including a non-abstract subclass of the module instead.");
+    }
   }
 
   @Test

--- a/integration-tests/src/test/java/com/example/ModuleAbstractInstanceProvidesMethod.java
+++ b/integration-tests/src/test/java/com/example/ModuleAbstractInstanceProvidesMethod.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = ModuleAbstractInstanceProvidesMethod.Module1.class)
+interface ModuleAbstractInstanceProvidesMethod {
+
+  String string();
+
+  @Module
+  abstract class Module1 {
+    @Provides
+    String string() {
+      return "foo";
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/example/ModuleInterfaceDefaultProvidesMethod.java
+++ b/integration-tests/src/test/java/com/example/ModuleInterfaceDefaultProvidesMethod.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = ModuleInterfaceDefaultProvidesMethod.Module1.class)
+interface ModuleInterfaceDefaultProvidesMethod {
+
+  String string();
+
+  @Module
+  interface Module1 {
+    @Provides
+    default String string() {
+      return "foo";
+    }
+  }
+}

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -75,16 +75,17 @@ final class ReflectiveModuleParser {
             }
           }
         } else {
-          if (!Modifier.isStatic(method.getModifiers()) && instance == null) {
-            // Try to just-in-time create an instance of the module using a default constructor.
-            instance = maybeInstantiate(moduleClass);
-            if (instance == null) {
-              throw new IllegalStateException(moduleClass.getCanonicalName() + " must be set");
-            }
-          }
-
           if (method.getAnnotation(Provides.class) != null) {
             ensureNotPrivate(method);
+            if (!Modifier.isStatic(method.getModifiers()) && instance == null) {
+              ensureNotAbstract(moduleClass);
+              // Try to just-in-time create an instance of the module using a default constructor.
+              instance = maybeInstantiate(moduleClass);
+              if (instance == null) {
+                throw new IllegalStateException(moduleClass.getCanonicalName() + " must be set");
+              }
+            }
+
             Key key = Key.of(qualifier, returnType);
             Binding binding = new UnlinkedProvidesBinding(instance, method);
             addBinding(scopeBuilder, key, binding, annotations);
@@ -191,6 +192,15 @@ final class ReflectiveModuleParser {
   private static void ensureNotPrivate(Method method) {
     if (Modifier.isPrivate(method.getModifiers())) {
       throw new IllegalArgumentException("Provides methods may not be private: " + method);
+    }
+  }
+
+  private static void ensureNotAbstract(Class<?> moduleClass) {
+    if (Modifier.isAbstract(moduleClass.getModifiers())) {
+      throw new IllegalStateException(
+          moduleClass.getCanonicalName()
+              + " is abstract and has instance @Provides methods."
+              + " Consider making the methods static or including a non-abstract subclass of the module instead.");
     }
   }
 }


### PR DESCRIPTION
Having unrelated methods in the Modules shouldn't alter behavior. Here are the fixes contained in this PR:
 * **Allow unrelated default methods on Module interfaces.**  
   Test to make sure it doesn't regress. (that test was failing at the time of original PR)
* **Unrelated instance methods don't trigger implicit module creation.**  
   Because the instance = maybeInstantiate(moduleClass)` was outside the `@Provides` annotation check, unrelated instance methods could trigger creating an instance.
 * **Disallow `@Provides` default method on interfaces.**
 * **Disallow `@provides` instance method on non-instantiatable abstract class.**  
    These two are compile errors in Dagger, make an explicit check to have a better error message.