### PR TITLE
Update auto-value to 1.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
       'auto': [
           'service': 'com.google.auto.service:auto-service:1.0-rc4',
           'value': [
-              'annotations': 'com.google.auto.value:auto-value-annotations:1.6.2',
-              'compiler': 'com.google.auto.value:auto-value:1.6.2',
+              'annotations': 'com.google.auto.value:auto-value-annotations:1.6.3',
+              'compiler': 'com.google.auto.value:auto-value:1.6.3',
           ],
       ],
       'jetbrainsAnnotations': 'org.jetbrains:annotations:16.0.3',


### PR DESCRIPTION
This fixes an error-prone warning about useless parenthesis.