### PR TITLE
Rename component parser to dependency parser

### DIFF
--- a/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
@@ -94,12 +94,12 @@ final class ComponentBuilderInvocationHandler implements InvocationHandler {
         ReflectiveModuleParser.parse(entry.getKey(), entry.getValue(), bindingsBuilder);
       }
       for (Map.Entry<Class<?>, Object> entry : dependencyInstances.entrySet()) {
-        Class<?> key = entry.getKey();
-        Object value = entry.getValue();
-        if (value == null) {
-          throw new IllegalStateException(key.getCanonicalName() + " must be set");
+        Class<?> type = entry.getKey();
+        Object instance = entry.getValue();
+        if (instance == null) {
+          throw new IllegalStateException(type.getCanonicalName() + " must be set");
         }
-        ReflectiveComponentParser.parse(key, value, bindingsBuilder);
+        ReflectiveDependencyParser.parse(type, instance, bindingsBuilder);
       }
       Scope scope = new Scope(bindingsBuilder.build());
 

--- a/reflect/src/main/java/dagger/reflect/ReflectiveDependencyParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveDependencyParser.java
@@ -7,11 +7,11 @@ import java.lang.reflect.Type;
 
 import static dagger.reflect.Reflection.findQualifier;
 
-final class ReflectiveComponentParser {
+final class ReflectiveDependencyParser {
   private static final LinkedBinding<?>[] NO_BINDINGS = new LinkedBinding<?>[0];
 
-  static void parse(Class<?> moduleClass, Object instance, BindingMap.Builder bindingsBuilder) {
-    for (Class<?> target : Reflection.getDistinctTypeHierarchy(moduleClass)) {
+  static void parse(Class<?> cls, Object instance, BindingMap.Builder bindingsBuilder) {
+    for (Class<?> target : Reflection.getDistinctTypeHierarchy(cls)) {
       for (Method method : target.getDeclaredMethods()) {
         if (method.getParameterTypes().length != 0 || method.getReturnType() == void.class) {
           continue; // Not a provision method.
@@ -28,7 +28,7 @@ final class ReflectiveComponentParser {
     }
   }
 
-  private ReflectiveComponentParser() {
+  private ReflectiveDependencyParser() {
     throw new AssertionError();
   }
 }


### PR DESCRIPTION
This is a more accurate description of the functionality. Especially since I plan to introduce a component parser to generalize component/subcomponent handling.