### PR TITLE
Added an integration test for a final module

### DIFF
--- a/integration-tests/src/main/java/com/example/ImplicitFinalModules.java
+++ b/integration-tests/src/main/java/com/example/ImplicitFinalModules.java
@@ -1,0 +1,20 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = ImplicitFinalModules.Module1.class)
+public interface ImplicitFinalModules {
+
+  String string();
+
+  @Module final class Module1 {
+
+    public static final String VALUE = "one";
+
+    @Provides String string() {
+      return VALUE;
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -159,6 +159,14 @@ public final class IntegrationTest {
     assertThat(component.string()).isEqualTo("4");
   }
 
+  @Test public void implicitModules() {
+    ignoreReflectionBackend();
+
+    ImplicitFinalModules component = backend.create(ImplicitFinalModules.class);
+
+    assertThat(component.string()).isEqualTo(ImplicitFinalModules.Module1.VALUE);
+  }
+
   @Test public void builderExplicitModulesOmitted() {
     try {
       backend.builder(BuilderExplicitModules.Builder.class).build();


### PR DESCRIPTION
Right now the reflection backend fails with 
`java.lang.IllegalStateException: com.example.ImplicitFinalModules.Module1 must be set`

However it should not as the module is no-arg and dagger parses it fine.

I ran into this scenario when testing dagger-reflect with my audiobook player and this is the commit that fixed it: https://github.com/PaulWoitaschek/Voice/commit/40e6daf20619470e599bcab29154bb45953adb81