### PR TITLE
Check for Builder annotations now that they have runtime retention

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 
 buildscript {
   ext.versions = [
-      'dagger': '2.21',
+      'dagger': 'HEAD-SNAPSHOT', // TODO update to 2.22 or newer once released
   ]
 
   ext.deps = [
@@ -61,6 +61,9 @@ subprojects {
       content {
         includeGroup 'org.jetbrains.trove4j'
       }
+    }
+    maven {
+      url 'https://oss.sonatype.org/content/repositories/snapshots/'
     }
   }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -6,7 +6,6 @@ dependencies {
   implementation deps.guava
   implementation deps.auto.value.annotations
   annotationProcessor deps.dagger.compiler
-  annotationProcessor deps.auto.value.annotations // TODO remove once Dagger releases fix
   annotationProcessor deps.auto.value.compiler
 
   testImplementation deps.junit

--- a/integration-tests/src/test/java/com/example/AbstractBuilderClass.java
+++ b/integration-tests/src/test/java/com/example/AbstractBuilderClass.java
@@ -4,5 +4,6 @@ import dagger.Component;
 
 @Component
 public interface AbstractBuilderClass {
+  @Component.Builder
   abstract class Builder {}
 }

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -721,7 +721,6 @@ public final class IntegrationTest {
 
   @Test public void noComponentBuilderAnnotationFails() {
     ignoreCodegenBackend();
-    ignoreReflectionBackend(); // @Component.Builder does not have runtime retention
 
     try {
       backend.builder(NoBuilderAnnotation.Builder.class);

--- a/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentInvocationHandler.java
@@ -94,11 +94,7 @@ final class ComponentInvocationHandler implements InvocationHandler {
         if (returnClass.getAnnotation(Subcomponent.class) != null) {
           return new SubcomponentMethodInvocationHandler(returnClass, scope);
         }
-        // TODO if (returnClass.getAnnotation(Subcomponent.Builder.class) != null) {
-        // Until @Subcomponent.Builder has runtime retention, check whether this return type belongs
-        // to a subcomponent builder by looking for an enclosing class annotated with @Subcomponent.
-        if (returnClass.getEnclosingClass() != null
-            && returnClass.getEnclosingClass().getAnnotation(Subcomponent.class) != null) {
+        if (returnClass.getAnnotation(Subcomponent.Builder.class) != null) {
           return new SubcomponentBuilderMethodInvocationhandler(returnClass, scope);
         }
       }

--- a/reflect/src/main/java/dagger/reflect/ReflectiveComponentBuilderParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveComponentBuilderParser.java
@@ -11,12 +11,10 @@ final class ReflectiveComponentBuilderParser {
   private static final Class<?>[] NO_DEPENDENCIES = new Class<?>[0];
 
   static <B> B parse(Class<B> cls) {
-    // TODO file a bug to get this retained for reflective access? Or maybe we don't care...
-    //Component.Builder builder = cls.getAnnotation(Component.Builder.class);
-    //if (builder == null) {
-    //  throw new IllegalArgumentException(
-    //      cls.getName() + " lacks @Component.Builder annotation");
-    //}
+    if (cls.getAnnotation(Component.Builder.class) == null) {
+      throw new IllegalArgumentException(
+          cls.getCanonicalName() + " lacks @Component.Builder annotation");
+    }
 
     Class<?> componentClass = cls.getEnclosingClass();
     if (componentClass == null) {


### PR DESCRIPTION
This requires using a snapshot build, for now. Once released in 2.22 we will go back to depending on a fixed version.