### PR TITLE
Move JIT binding lookup to Scope

### DIFF
--- a/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
+++ b/reflect/src/main/java/dagger/reflect/ComponentBuilderInvocationHandler.java
@@ -95,8 +95,7 @@ final class ComponentBuilderInvocationHandler implements InvocationHandler {
         throw new IllegalStateException(); // TODO must be no-arg
       }
 
-      BindingMap.Builder bindingsBuilder = new BindingMap.Builder()
-          .justInTimeProvider(new ReflectiveJustInTimeProvider());
+      BindingMap.Builder bindingsBuilder = new BindingMap.Builder();
 
       for (Map.Entry<Key, Object> entry : boundInstances.entrySet()) {
         bindingsBuilder.add(entry.getKey(), new LinkedInstanceBinding<>(entry.getValue()));
@@ -112,7 +111,9 @@ final class ComponentBuilderInvocationHandler implements InvocationHandler {
         }
         ReflectiveDependencyParser.parse(type, instance, bindingsBuilder);
       }
-      Scope scope = new Scope(bindingsBuilder.build(), parent);
+
+      JustInTimeBindingFactory jitBindingFactory = new ReflectiveJustInTimeBindingFactory();
+      Scope scope = new Scope(bindingsBuilder.build(), jitBindingFactory, parent);
 
       return ComponentInvocationHandler.create(componentClass, scope);
     }

--- a/reflect/src/main/java/dagger/reflect/JustInTimeBindingFactory.java
+++ b/reflect/src/main/java/dagger/reflect/JustInTimeBindingFactory.java
@@ -1,0 +1,8 @@
+package dagger.reflect;
+
+import dagger.reflect.Binding.UnlinkedBinding;
+import org.jetbrains.annotations.Nullable;
+
+interface JustInTimeBindingFactory {
+  @Nullable UnlinkedBinding create(Key key);
+}

--- a/reflect/src/main/java/dagger/reflect/Linker.java
+++ b/reflect/src/main/java/dagger/reflect/Linker.java
@@ -42,7 +42,7 @@ final class Linker {
     LinkedBinding<?> linkedBinding = unlinkedBinding.link(this);
     chain.remove(key);
 
-    return bindings.replaceLinked(key, unlinkedBinding, linkedBinding);
+    return bindings.replace(key, unlinkedBinding, linkedBinding);
   }
 
   private RuntimeException failure(Key key, String reason, String cause) {

--- a/reflect/src/main/java/dagger/reflect/ReflectiveComponentParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveComponentParser.java
@@ -46,13 +46,15 @@ final class ReflectiveComponentParser {
       throw notImplemented("Scoped components");
     }
 
-    BindingMap.Builder bindingsBuilder = new BindingMap.Builder()
-        .justInTimeProvider(new ReflectiveJustInTimeProvider());
+    BindingMap.Builder bindingsBuilder = new BindingMap.Builder();
 
     for (Class<?> module : modules) {
       ReflectiveModuleParser.parse(module, null, bindingsBuilder);
     }
-    Scope scope = new Scope(bindingsBuilder.build(), parent);
+
+    JustInTimeBindingFactory jitBindingFactory = new ReflectiveJustInTimeBindingFactory();
+    Scope scope = new Scope(bindingsBuilder.build(), jitBindingFactory, parent);
+
     return ComponentInvocationHandler.create(cls, scope);
   }
 }

--- a/reflect/src/main/java/dagger/reflect/ReflectiveJustInTimeBindingFactory.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveJustInTimeBindingFactory.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import static dagger.reflect.DaggerReflect.notImplemented;
 import static dagger.reflect.Reflection.findScope;
 
-final class ReflectiveJustInTimeProvider implements BindingMap.JustInTimeProvider {
+final class ReflectiveJustInTimeBindingFactory implements JustInTimeBindingFactory {
   @Override public @Nullable UnlinkedBinding create(Key key) {
     Annotation qualifier = key.qualifier();
     if (qualifier != null) {

--- a/reflect/src/main/java/dagger/reflect/Scope.java
+++ b/reflect/src/main/java/dagger/reflect/Scope.java
@@ -7,24 +7,48 @@ import org.jetbrains.annotations.Nullable;
 
 final class Scope {
   private final BindingMap bindings;
+  private final JustInTimeBindingFactory jitBindingFactory;
   private final @Nullable Scope parent;
 
-  Scope(BindingMap bindings, @Nullable Scope parent) {
+  Scope(BindingMap bindings, JustInTimeBindingFactory jitBindingFactory, @Nullable Scope parent) {
     this.bindings = bindings;
+    this.jitBindingFactory = jitBindingFactory;
     this.parent = parent;
   }
 
-  Provider<?> getProvider(Key key) {
+  /**
+   * Look for a linked binding for {@code key} in this scope or anywhere in the parent scope chain.
+   * If an unlinked binding is found for the key, perform linking before returning it.
+   */
+  private @Nullable LinkedBinding<?> findBinding(Key key) {
     Binding binding = bindings.get(key);
-    if (binding instanceof LinkedBinding<?>) {
-      return (Provider<?>) binding;
-    }
     if (binding != null) {
-      return Linker.link(bindings, key, (UnlinkedBinding) binding);
+      return binding instanceof LinkedBinding<?>
+          ? (LinkedBinding<?>) binding
+          :  Linker.link(bindings, key, (UnlinkedBinding) binding);
     }
-    if (parent != null) {
-      return parent.getProvider(key);
+
+    return parent != null
+        ? parent.findBinding(key)
+        : null;
+  }
+
+  Provider<?> getProvider(Key key) {
+    LinkedBinding<?> binding = findBinding(key);
+    if (binding != null) {
+      return binding;
     }
+
+    Binding jitBinding = jitBindingFactory.create(key);
+    if (jitBinding != null) {
+      // TODO figure out if scoped and walk up hierarchy looking for a matching scope.
+
+      jitBinding = bindings.putIfAbsent(key, jitBinding);
+      return jitBinding instanceof LinkedBinding<?>
+          ? (LinkedBinding<?>) jitBinding
+          : Linker.link(bindings, key, (UnlinkedBinding) jitBinding);
+    }
+
     throw new IllegalArgumentException("No provider available for " + key);
   }
 }


### PR DESCRIPTION
This is in prepartion for honoring scope annotations. If the JIT binding factory loads a class which is scoped we'll need to traverse the hierarchy to find which scope to add it to.