### PR TITLE
Parse into the Scope.Builder to honor scopes

### DIFF
--- a/integration-tests/src/main/java/com/example/Scoped.java
+++ b/integration-tests/src/main/java/com/example/Scoped.java
@@ -3,20 +3,17 @@ package com.example;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Singleton;
 
 @Singleton
 @Component(modules = Scoped.Module1.class)
 interface Scoped {
-  int value();
+  Object value();
 
   @Module
   abstract class Module1 {
-    private static final AtomicInteger count = new AtomicInteger(1);
-
-    @Provides @Singleton static int value() {
-      return count.getAndIncrement();
+    @Provides @Singleton static Object value() {
+      return new Object();
     }
   }
 }

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -392,11 +392,21 @@ public final class IntegrationTest {
   }
 
   @Test public void scoped() {
-    ignoreReflectionBackend();
-
     Scoped component = backend.create(Scoped.class);
-    assertThat(component.value()).isEqualTo(1);
-    assertThat(component.value()).isEqualTo(1);
+    Object value1 = component.value();
+    Object value2 = component.value();
+    assertThat(value1).isSameAs(value2);
+  }
+
+  @Test public void scopedWrong() {
+    ignoreCodegenBackend();
+
+    try {
+      backend.create(ScopedWrong.class);
+      fail();
+    } catch (IllegalStateException e) {
+      // TODO some message indicating wrong scope
+    }
   }
 
   @Test public void multibindingSet() {

--- a/integration-tests/src/test/java/com/example/ScopedWrong.java
+++ b/integration-tests/src/test/java/com/example/ScopedWrong.java
@@ -1,0 +1,27 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Scope;
+import javax.inject.Singleton;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+@Component(modules = ScopedWrong.Module1.class)
+interface ScopedWrong {
+  Object value();
+
+  @Module
+  abstract class Module1 {
+    @Provides @Unrelated static Object value() {
+      return new Object();
+    }
+  }
+
+  @Scope
+  @Retention(RUNTIME)
+  @interface Unrelated {}
+}

--- a/reflect/src/main/java/dagger/reflect/BindingMap.java
+++ b/reflect/src/main/java/dagger/reflect/BindingMap.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,9 +76,6 @@ final class BindingMap {
     private final Map<Key, Map<Object, Binding>> mapBindings = new LinkedHashMap<>();
 
     Builder add(Key key, Binding binding) {
-      if (key == null) throw new NullPointerException("key == null");
-      if (binding == null) throw new NullPointerException("binding == null");
-
       Binding replaced = bindings.put(key, binding);
       if (replaced != null) {
         throw new IllegalStateException(
@@ -88,22 +84,7 @@ final class BindingMap {
       return this;
     }
 
-    /**
-     * Adds a new element into the set specified by {@code key}.
-     *
-     * @param key They key defining the set in which this element will be added. The raw class of
-     * the {@linkplain Key#type() type} must be {@link Set Set.class}.
-     * @param elementBinding The binding for the new element. The instance produced by this binding
-     * must be an instance of the {@code E} type parameter of {@link Set} specified
-     * {@linkplain Key#type() in the <code>key</code>}.
-     */
     Builder addIntoSet(Key key, Binding elementBinding) {
-      if (key == null) throw new NullPointerException("key == null");
-      if (Types.getRawType(key.type()) != Set.class) {
-        throw new IllegalArgumentException("key.type() must be Set");
-      }
-      if (elementBinding == null) throw new NullPointerException("elementBinding == null");
-
       SetBindings bindings = setBindings.get(key);
       if (bindings == null) {
         bindings = new SetBindings();
@@ -114,21 +95,7 @@ final class BindingMap {
       return this;
     }
 
-    /**
-     * Adds a new element into the set specified by {@code key}.
-     *
-     * @param key They key defining the set in which this element will be added. The raw class of
-     * the {@linkplain Key#type() type} must be {@link Set Set.class}.
-     * @param elementsBinding The binding for the elements. The instance produced by this binding
-     * must be an instance of {@code Set<E>} matching {@link Key#type() key.type()}.
-     */
     Builder addElementsIntoSet(Key key, Binding elementsBinding) {
-      if (key == null) throw new NullPointerException("key == null");
-      if (Types.getRawType(key.type()) != Set.class) {
-        throw new IllegalArgumentException("key.type() must be Set");
-      }
-      if (elementsBinding == null) throw new NullPointerException("elementsBinding == null");
-
       SetBindings bindings = setBindings.get(key);
       if (bindings == null) {
         bindings = new SetBindings();
@@ -139,26 +106,7 @@ final class BindingMap {
       return this;
     }
 
-    /**
-     * Adds a new entry into the map specified by {@code key}.
-     *
-     * @param key The key defining the map in which this entry will be added. The raw class of the
-     * {@linkplain Key#type() type} must be {@link Map Map.class}.
-     * @param entryKey The key of the new map entry. The argument must be an instance of the
-     * {@code K} type parameter of {@link Map} specified
-     * {@linkplain Key#type() in the <code>key</code>}.
-     * @param entryValueBinding The value binding of the new map entry. The instance produced by
-     * this binding must be an instance of the {@code V} type parameter of {@link Map} specified
-     * {@linkplain Key#type()} in the <code>key</code>}.
-     */
     Builder addIntoMap(Key key, Object entryKey, Binding entryValueBinding) {
-      if (key == null) throw new NullPointerException("key == null");
-      if (Types.getRawType(key.type()) != Map.class) {
-        throw new IllegalArgumentException("key.type() must be Map");
-      }
-      if (entryKey == null) throw new NullPointerException("entryKey == null");
-      if (entryValueBinding == null) throw new NullPointerException("entryValueBinding == null");
-
       Map<Object, Binding> mapBinding = mapBindings.get(key);
       if (mapBinding == null) {
         mapBinding = new LinkedHashMap<>();

--- a/reflect/src/main/java/dagger/reflect/ReflectiveDependencyParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveDependencyParser.java
@@ -10,7 +10,7 @@ import static dagger.reflect.Reflection.findQualifier;
 final class ReflectiveDependencyParser {
   private static final LinkedBinding<?>[] NO_BINDINGS = new LinkedBinding<?>[0];
 
-  static void parse(Class<?> cls, Object instance, BindingMap.Builder bindingsBuilder) {
+  static void parse(Class<?> cls, Object instance, Scope.Builder scopeBuilder) {
     for (Class<?> target : Reflection.getDistinctTypeHierarchy(cls)) {
       for (Method method : target.getDeclaredMethods()) {
         if (method.getParameterTypes().length != 0 || method.getReturnType() == void.class) {
@@ -23,7 +23,7 @@ final class ReflectiveDependencyParser {
 
         Binding binding = new LinkedProvidesBinding<>(instance, method, NO_BINDINGS);
 
-        bindingsBuilder.add(key, binding);
+        scopeBuilder.addBinding(key, binding);
       }
     }
   }


### PR DESCRIPTION
This allows the parsers to validate the scoping annotations of the bindings they're creating.