### PR TITLE
Allow private helper methods in modules.

### DIFF
--- a/integration-tests/src/main/java/com/example/ModulePrivateMethod.java
+++ b/integration-tests/src/main/java/com/example/ModulePrivateMethod.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component(modules = ModulePrivateMethod.ModuleWithPrivateMethods.class)
+public interface ModulePrivateMethod {
+
+    Integer integer();
+
+    @Module
+    class ModuleWithPrivateMethods {
+        @Provides Integer integer() {
+            return helperPrivateMethod();
+        }
+        private Integer helperPrivateMethod() {
+            return helperPrivateStaticMethod();
+        }
+
+        private static Integer helperPrivateStaticMethod() {
+            return 42;
+        }
+    }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -509,6 +509,11 @@ public final class IntegrationTest {
     assertThat(component.number()).isEqualTo(42);
   }
 
+  @Test public void modulePrivateMethod() {
+    ModulePrivateMethod component = backend.create(ModulePrivateMethod.class);
+    assertThat(component.integer()).isEqualTo(42);
+  }
+
   @Test public void nestedComponent() {
     NestedComponent.MoreNesting.AndMore.TheComponent component =
         backend.create(NestedComponent.MoreNesting.AndMore.TheComponent.class);

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -29,12 +29,12 @@ final class ReflectiveModuleParser {
   static void parse(Class<?> moduleClass, @Nullable Object instance, Scope.Builder scopeBuilder) {
     for (Class<?> target : Reflection.getDistinctTypeHierarchy(moduleClass)) {
       for (Method method : target.getDeclaredMethods()) {
-        if ((method.getModifiers() & PRIVATE) != 0) {
-          throw new IllegalArgumentException("Private module methods are not allowed: " + method);
+        Annotation[] annotations = method.getAnnotations();
+        if ((method.getModifiers() & PRIVATE) != 0 && (annotations == null)) {
+          throw new IllegalArgumentException("Private module methods with annotations are not allowed: " + method);
         }
 
         Type returnType = method.getGenericReturnType();
-        Annotation[] annotations = method.getAnnotations();
         Annotation qualifier = findQualifier(annotations);
 
         if ((method.getModifiers() & ABSTRACT) != 0) {

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -29,12 +29,8 @@ final class ReflectiveModuleParser {
   static void parse(Class<?> moduleClass, @Nullable Object instance, Scope.Builder scopeBuilder) {
     for (Class<?> target : Reflection.getDistinctTypeHierarchy(moduleClass)) {
       for (Method method : target.getDeclaredMethods()) {
-        Annotation[] annotations = method.getAnnotations();
-        if ((method.getModifiers() & PRIVATE) != 0 && (annotations == null)) {
-          throw new IllegalArgumentException("Private module methods with annotations are not allowed: " + method);
-        }
-
         Type returnType = method.getGenericReturnType();
+        Annotation[] annotations = method.getAnnotations();
         Annotation qualifier = findQualifier(annotations);
 
         if ((method.getModifiers() & ABSTRACT) != 0) {
@@ -69,6 +65,7 @@ final class ReflectiveModuleParser {
           }
 
           if (method.getAnnotation(Provides.class) != null) {
+            ensureNotPrivate(method);
             Key key = Key.of(qualifier, returnType);
             Binding binding = new UnlinkedProvidesBinding(instance, method);
             addBinding(scopeBuilder, key, binding, annotations);
@@ -146,5 +143,11 @@ final class ReflectiveModuleParser {
     Key key = Key.of(entryValueKey.qualifier(),
         new ParameterizedTypeImpl(null, Map.class, entryKeyType, entryValueKey.type()));
     scopeBuilder.addBindingIntoMap(key, entryKey, entryValueBinding);
+  }
+
+  private static void ensureNotPrivate(Method method) {
+    if ((method.getModifiers() & PRIVATE) != 0) {
+      throw new IllegalArgumentException("Provides methods may not be private: " + method);
+    }
   }
 }


### PR DESCRIPTION
We have a couple of private helper methods in our modules.
This changes the behavior to allow private methods in modules if and
only if they have no annotations.

An alternative is to keep a blacklist of annotations which are not allowed
on private methods such as `@Provides`?