### PR TITLE
Change LinkedBinding to not be a Provider

### DIFF
--- a/reflect/src/main/java/dagger/reflect/Binding.java
+++ b/reflect/src/main/java/dagger/reflect/Binding.java
@@ -15,7 +15,7 @@
  */
 package dagger.reflect;
 
-import javax.inject.Provider;
+import org.jetbrains.annotations.Nullable;
 
 interface Binding {
   LinkedBinding<?> link(Linker linker);
@@ -28,7 +28,9 @@ interface Binding {
     }
   }
 
-  abstract class LinkedBinding<T> implements Binding, Provider<T> {
+  abstract class LinkedBinding<T> implements Binding {
+    abstract @Nullable T get();
+
     @Override public final LinkedBinding<?> link(Linker linker) {
       return this;
     }


### PR DESCRIPTION
We are going to start handling requests for `Provider<T>` soon and this will be confusing. A `LinkedBinding<Provider<T>>` would be a `Provider<Provider<T>>` then and I don't want to get caught up in accidentally interpreting the `LinkedBinding` itself as a `Provider` which it is not (providers should link lazily).