### PR TITLE
Use auto-service-annotations for compiling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,10 @@ buildscript {
       'compileTesting': 'com.google.testing.compile:compile-testing:0.15',
       'javaPoet': 'com.squareup:javapoet:1.11.1',
       'auto': [
-          'service': 'com.google.auto.service:auto-service:1.0-rc4',
+          'service': [
+              'annotations': 'com.google.auto.service:auto-service-annotations:1.0-rc5',
+              'compiler': 'com.google.auto.service:auto-service:1.0-rc5',
+          ],
           'value': [
               'annotations': 'com.google.auto.value:auto-value-annotations:1.6.3',
               'compiler': 'com.google.auto.value:auto-value:1.6.3',

--- a/reflect-compiler/build.gradle
+++ b/reflect-compiler/build.gradle
@@ -9,9 +9,10 @@ dependencies {
   implementation project(':reflect')
   implementation deps.javaPoet
   implementation deps.dagger.runtime
+  implementation deps.jetbrainsAnnotations
 
-  compileOnly deps.auto.service
-  annotationProcessor deps.auto.service
+  compileOnly deps.auto.service.annotations
+  annotationProcessor deps.auto.service.compiler
 
   compileOnly deps.incap.runtime
   annotationProcessor deps.incap.processor

--- a/reflect-compiler/src/main/java/dagger/reflect/compiler/DaggerReflectCompiler.java
+++ b/reflect-compiler/src/main/java/dagger/reflect/compiler/DaggerReflectCompiler.java
@@ -23,7 +23,6 @@ import com.squareup.javapoet.TypeSpec;
 import dagger.Component;
 import dagger.reflect.DaggerReflect;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -34,6 +33,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Collections.singleton;
 import static javax.lang.model.element.Modifier.FINAL;


### PR DESCRIPTION
This prevents leaking the auto-service dependencies into the classpath. And as a result, switch to JetBrains' annotations since we previously used JSR305 ones added transitively from auto-service.