### PR TITLE
Don't suppress a valid EP check globally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,6 @@ subprojects {
       disableWarningsInGeneratedCode = true
       excludedPaths = ".*/build/generated/.*"
 
-      check("JavaxInjectOnAbstractMethod", CheckSeverity.OFF)
-
       nullaway {
         annotatedPackages.add('dagger.reflect')
         severity = CheckSeverity.ERROR

--- a/integration-tests/src/test/java/com/example/MembersInjectionAbstractMethod.java
+++ b/integration-tests/src/test/java/com/example/MembersInjectionAbstractMethod.java
@@ -10,6 +10,7 @@ public interface MembersInjectionAbstractMethod {
   void inject(Target instance);
 
   abstract class Target {
+    @SuppressWarnings("JavaxInjectOnAbstractMethod") // Known incorrect behavior under test.
     @Inject abstract void abstractMethod(String one);
   }
 

--- a/integration-tests/src/test/java/com/example/MembersInjectionInterfaceMethod.java
+++ b/integration-tests/src/test/java/com/example/MembersInjectionInterfaceMethod.java
@@ -10,6 +10,7 @@ public interface MembersInjectionInterfaceMethod {
   void inject(Target instance);
 
   interface Target {
+    @SuppressWarnings("JavaxInjectOnAbstractMethod") // Known incorrect behavior under test.
     @Inject void interfaceMethod(String one);
   }
 


### PR DESCRIPTION
Suppress locally at usage sites where we're expicitly testing this behavior.