### PR TITLE
Exclude more functional tests

### DIFF
--- a/integration-tests/upstream/build.gradle
+++ b/integration-tests/upstream/build.gradle
@@ -37,7 +37,14 @@ test.filter {
   excludeTest 'dagger.functional.NestedTest', 'nestedFoo'
 
   // TODO reflect bug! Need something like ByteBuddy for proxying classes at runtime.
+  excludeTest 'dagger.functional.builder.BuilderBindsInstanceParameterTest', null
   excludeTest 'dagger.functional.builderbinds.BuilderBindsTest', null
+  excludeTest 'dagger.functional.factory.FactoryBindsInstanceTest', null
+  excludeTest 'dagger.functional.factory.FactoryDependenciesTest', null
+  excludeTest 'dagger.functional.factory.FactoryImplicitModulesTest', null
+  excludeTest 'dagger.functional.factory.FactoryMixedParametersTest', null
+  excludeTest 'dagger.functional.factory.FactoryRequiredModulesTest', null
+  excludeTest 'dagger.functional.factory.SubcomponentFactoryTest', null
   excludeTest 'dagger.functional.subcomponent.SubcomponentTest', null
   excludeTest 'dagger.functional.subcomponent.repeat.RepeatedModuleTest', null
   excludeTest 'dagger.functional.BasicTest', null


### PR DESCRIPTION
Two commits with different ancestors allowed these failing tests to make it to master.