### PR TITLE
Ensure that primitives are boxed when put in parameterized types

### DIFF
--- a/integration-tests/src/main/java/com/example/MultibindingMapPrimitiveKey.java
+++ b/integration-tests/src/main/java/com/example/MultibindingMapPrimitiveKey.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoMap;
+import dagger.multibindings.LongKey;
+import java.util.Map;
+
+@Component(modules = MultibindingMapPrimitiveKey.Module1.class)
+interface MultibindingMapPrimitiveKey {
+  Map<Long, String> values();
+
+  @Module
+  abstract class Module1 {
+    @Provides @IntoMap @LongKey(1L) static String one() {
+      return "one";
+    }
+    @Provides @IntoMap @LongKey(2L) static String two() {
+      return "two";
+    }
+  }
+}

--- a/integration-tests/src/main/java/com/example/MultibindingMapPrimitiveValue.java
+++ b/integration-tests/src/main/java/com/example/MultibindingMapPrimitiveValue.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoMap;
+import dagger.multibindings.StringKey;
+import java.util.Map;
+
+@Component(modules = MultibindingMapPrimitiveValue.Module1.class)
+interface MultibindingMapPrimitiveValue {
+  Map<String, Long> values();
+
+  @Module
+  abstract class Module1 {
+    @Provides @IntoMap @StringKey("1") static long one() {
+      return 1L;
+    }
+    @Provides @IntoMap @StringKey("2") static long two() {
+      return 2L;
+    }
+  }
+}

--- a/integration-tests/src/main/java/com/example/MultibindingSetElementsPrimitive.java
+++ b/integration-tests/src/main/java/com/example/MultibindingSetElementsPrimitive.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.ElementsIntoSet;
+import dagger.multibindings.IntoSet;
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+
+@Component(modules = MultibindingSetElementsPrimitive.Module1.class)
+interface MultibindingSetElementsPrimitive {
+  Set<Long> values();
+
+  @Module
+  abstract class Module1 {
+    @Provides @ElementsIntoSet static Set<Long> one() {
+      return singleton(1L);
+    }
+    @Provides @IntoSet static long two() {
+      return 2L;
+    }
+  }
+}

--- a/integration-tests/src/main/java/com/example/MultibindingSetPrimitive.java
+++ b/integration-tests/src/main/java/com/example/MultibindingSetPrimitive.java
@@ -1,0 +1,22 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoSet;
+import java.util.Set;
+
+@Component(modules = MultibindingSetPrimitive.Module1.class)
+interface MultibindingSetPrimitive {
+  Set<Long> values();
+
+  @Module
+  abstract class Module1 {
+    @Provides @IntoSet static long one() {
+      return 1L;
+    }
+    @Provides @IntoSet static long two() {
+      return 2L;
+    }
+  }
+}

--- a/integration-tests/src/main/java/com/example/OptionalBindingPrimitive.java
+++ b/integration-tests/src/main/java/com/example/OptionalBindingPrimitive.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import dagger.BindsOptionalOf;
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import java.util.Optional;
+
+@Component(modules = OptionalBindingPrimitive.Module1.class)
+public interface OptionalBindingPrimitive {
+  Optional<Long> five();
+
+  @Module
+  abstract class Module1 {
+    @Provides static long five() {
+      return 5L;
+    }
+
+    @BindsOptionalOf abstract long optionalFive();
+  }
+}

--- a/integration-tests/src/main/java/com/example/OptionalGuavaBindingAbsent.java
+++ b/integration-tests/src/main/java/com/example/OptionalGuavaBindingAbsent.java
@@ -5,6 +5,7 @@ import dagger.BindsOptionalOf;
 import dagger.Component;
 import dagger.Module;
 
+@SuppressWarnings("Guava") // Explicitly testing Guava support.
 @Component(modules = OptionalGuavaBindingAbsent.Module1.class)
 public interface OptionalGuavaBindingAbsent {
   Optional<String> string();

--- a/integration-tests/src/main/java/com/example/OptionalGuavaBindingPrimitive.java
+++ b/integration-tests/src/main/java/com/example/OptionalGuavaBindingPrimitive.java
@@ -7,16 +7,16 @@ import dagger.Module;
 import dagger.Provides;
 
 @SuppressWarnings("Guava") // Explicitly testing Guava support.
-@Component(modules = OptionalGuavaBinding.Module1.class)
-public interface OptionalGuavaBinding {
-  Optional<String> string();
+@Component(modules = OptionalGuavaBindingPrimitive.Module1.class)
+public interface OptionalGuavaBindingPrimitive {
+  Optional<Long> five();
 
   @Module
   abstract class Module1 {
-    @Provides static String foo() {
-      return "foo";
+    @Provides static long five() {
+      return 5L;
     }
 
-    @BindsOptionalOf abstract String optionalFoo();
+    @BindsOptionalOf abstract long optionalFive();
   }
 }

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -92,6 +92,12 @@ public final class IntegrationTest {
     assertThat(component.string()).isEqualTo(Optional.empty());
   }
 
+  @Test public void optionalBindingPrimitive() {
+    OptionalBindingPrimitive component = backend.create(OptionalBindingPrimitive.class);
+    assertThat(component.five()).isEqualTo(Optional.of(5L));
+  }
+
+  @SuppressWarnings("Guava") // Explicitly testing Guava support.
   @Test public void optionalGuavaBinding() {
     OptionalGuavaBinding component = backend.create(OptionalGuavaBinding.class);
     assertThat(component.string()).isEqualTo(com.google.common.base.Optional.of("foo"));
@@ -100,6 +106,12 @@ public final class IntegrationTest {
   @Test public void optionalGuavaBindingAbsent() {
     OptionalGuavaBindingAbsent component = backend.create(OptionalGuavaBindingAbsent.class);
     assertThat(component.string()).isEqualTo(com.google.common.base.Optional.absent());
+  }
+
+  @SuppressWarnings("Guava") // Explicitly testing Guava support.
+  @Test public void optionalGuavaBindingPrimitive() {
+    OptionalGuavaBindingPrimitive component = backend.create(OptionalGuavaBindingPrimitive.class);
+    assertThat(component.five()).isEqualTo(com.google.common.base.Optional.of(5L));
   }
 
   @Test public void justInTimeConstructor() {
@@ -570,6 +582,17 @@ public final class IntegrationTest {
     assertThat(component.values()).containsExactly("one", "two");
   }
 
+  @Test public void multibindingSetPrimitive() {
+    MultibindingSetPrimitive component = backend.create(MultibindingSetPrimitive.class);
+    assertThat(component.values()).containsExactly(1L, 2L);
+  }
+
+  @Test public void multibindingSetElementsPrimitive() {
+    MultibindingSetElementsPrimitive component =
+        backend.create(MultibindingSetElementsPrimitive.class);
+    assertThat(component.values()).containsExactly(1L, 2L);
+  }
+
   @Test public void multibindingProviderSet() {
     ignoreReflectionBackend();
 
@@ -587,6 +610,16 @@ public final class IntegrationTest {
   @Test public void multibindingMap() {
     MultibindingMap component = backend.create(MultibindingMap.class);
     assertThat(component.values()).containsExactly("1", "one", "2", "two");
+  }
+
+  @Test public void multibindingMapPrimitiveKey() {
+    MultibindingMapPrimitiveKey component = backend.create(MultibindingMapPrimitiveKey.class);
+    assertThat(component.values()).containsExactly(1L, "one", 2L, "two");
+  }
+
+  @Test public void multibindingMapPrimitiveValue() {
+    MultibindingMapPrimitiveValue component = backend.create(MultibindingMapPrimitiveValue.class);
+    assertThat(component.values()).containsExactly("1", 1L, "2", 2L);
   }
 
   @Test public void multibindingMapNoUnwrap() {

--- a/integration-tests/upstream/build.gradle
+++ b/integration-tests/upstream/build.gradle
@@ -29,9 +29,6 @@ test.filter {
   // dagger-reflect does not produce the exact same behavior as dagger-compiler for @Reusable.
   excludeTest 'dagger.functional.ReusableTest', null
 
-  // TODO reflect bug! Not supporting primitives being bound into parameterized types.
-  excludeTest 'dagger.functional.binds.BindsTest', null
-
   // TODO reflect bug! Need something like ByteBuddy for proxying classes at runtime.
   excludeTest 'dagger.functional.builder.BuilderBindsInstanceParameterTest', null
   excludeTest 'dagger.functional.builderbinds.BuilderBindsTest', null
@@ -47,6 +44,7 @@ test.filter {
 
   // TODO reflect bug! Generics don't work well.
   excludeTest 'dagger.functional.GenericTest', null
+  excludeTest 'dagger.functional.binds.BindsTest', null
 
   // TODO reflect bug! Something with @IntoSet, set bindings, and subcomponents.
   excludeTest 'dagger.functional.subcomponent.pruning.SubcomponentOnlyRequestedBySiblingTest', 'subcomponentAddedInParent_onlyUsedInSibling'

--- a/reflect/src/main/java/dagger/reflect/Key.java
+++ b/reflect/src/main/java/dagger/reflect/Key.java
@@ -20,16 +20,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import org.jetbrains.annotations.Nullable;
 
+import static dagger.reflect.Reflection.boxIfNecessary;
+
 @AutoValue
 abstract class Key {
   static Key of(@Nullable Annotation qualifier, Type type) {
-    if (type instanceof Class<?>) {
-      Class<?> cls = (Class<?>) type;
-      if (cls.isPrimitive()) {
-        type = box(cls);
-      }
-    }
-    return new AutoValue_Key(qualifier, type);
+    return new AutoValue_Key(qualifier, boxIfNecessary(type));
   }
 
   abstract @Nullable Annotation qualifier();
@@ -62,18 +58,5 @@ abstract class Key {
       return cls.getName();
     }
     return type.toString();
-  }
-
-  private static Class<?> box(Class<?> cls) {
-    if (cls == boolean.class) return Boolean.class;
-    if (cls == byte.class) return Byte.class;
-    if (cls == char.class) return Character.class;
-    if (cls == double.class) return Double.class;
-    if (cls == float.class) return Float.class;
-    if (cls == int.class) return Integer.class;
-    if (cls == long.class) return Long.class;
-    if (cls == short.class) return Short.class;
-    if (cls == void.class) return Void.class;
-    throw new IllegalArgumentException("Only primitive types can be boxed: " + cls.getName());
   }
 }

--- a/reflect/src/main/java/dagger/reflect/Reflection.java
+++ b/reflect/src/main/java/dagger/reflect/Reflection.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -206,6 +207,25 @@ final class Reflection {
           + " is not an interface. Only interfaces are supported.");
     }
     return cls.cast(Proxy.newProxyInstance(cls.getClassLoader(), new Class<?>[] { cls }, handler));
+  }
+
+  static Type boxIfNecessary(Type type) {
+    if (type instanceof Class<?>) {
+      Class<?> cls = (Class<?>) type;
+      if (cls.isPrimitive()) {
+        if (cls == boolean.class) return Boolean.class;
+        if (cls == byte.class) return Byte.class;
+        if (cls == char.class) return Character.class;
+        if (cls == double.class) return Double.class;
+        if (cls == float.class) return Float.class;
+        if (cls == int.class) return Integer.class;
+        if (cls == long.class) return Long.class;
+        if (cls == short.class) return Short.class;
+        if (cls == void.class) return Void.class;
+        throw new AssertionError("Unknown primitive type: " + cls);
+      }
+    }
+    return type;
   }
 
   private Reflection() {


### PR DESCRIPTION
This can occur for Optional bindings, Set bindings, and Map bindings.