### PR TITLE
Have a slightly better error message when unable to find a jit binding.

### DIFF
--- a/reflect/src/main/java/dagger/reflect/Scope.java
+++ b/reflect/src/main/java/dagger/reflect/Scope.java
@@ -69,7 +69,7 @@ final class Scope {
     if (jitLookup != null) {
       LinkedBinding<?> jitBinding = putJitBinding(key, linker, jitLookup);
       if (jitBinding == null) {
-        throw new IllegalStateException(); // TODO nice error message with scope chain
+        throw new IllegalStateException("Unable to find binding for key=" + key + " and linker=" + linker); // TODO nice error message with scope chain
       }
       return jitBinding;
     }


### PR DESCRIPTION
This isn't the nice scope chain that we want, but at least it prints our
the missing key, which is bettter than nothing. It also prints out the
linker to know if was null or not.