### PR TITLE
Key should canonicalize Type input.

### DIFF
--- a/reflect/src/main/java/dagger/reflect/Key.java
+++ b/reflect/src/main/java/dagger/reflect/Key.java
@@ -21,11 +21,12 @@ import java.lang.reflect.Type;
 import org.jetbrains.annotations.Nullable;
 
 import static dagger.reflect.Reflection.boxIfNecessary;
+import static dagger.reflect.TypeUtil.canonicalize;
 
 @AutoValue
 abstract class Key {
   static Key of(@Nullable Annotation qualifier, Type type) {
-    return new AutoValue_Key(qualifier, boxIfNecessary(type));
+    return new AutoValue_Key(qualifier, canonicalize(boxIfNecessary(type)));
   }
 
   abstract @Nullable Annotation qualifier();


### PR DESCRIPTION
Otherwise created types cannot be compared properly.