### PR TITLE
Fix reusable just in time scoping.

### DIFF
--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -623,7 +623,6 @@ public final class IntegrationTest {
   }
 
   @Test public void reusableJustInTime() {
-    ignoreReflectionBackend();
     ReusableScopedJustInTime component = backend.create(ReusableScopedJustInTime.class);
     assertThat(component.bar()).isNotNull(); // Smoke test.
   }

--- a/reflect/src/main/java/dagger/reflect/Reflection.java
+++ b/reflect/src/main/java/dagger/reflect/Reflection.java
@@ -30,6 +30,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.inject.Qualifier;
 import javax.inject.Scope;
+
+import dagger.Reusable;
 import org.jetbrains.annotations.Nullable;
 
 final class Reflection {
@@ -66,9 +68,19 @@ final class Reflection {
     }
   }
 
+  /**
+   * Finds scoping annotations that aren't {@link Reusable}.
+   *
+   * @param annotations The set of annotations to parse for scoping annotations.
+   * @return All annotations with Scope or an empty set if none are found.
+   */
   static Set<Annotation> findScopes(Annotation[] annotations) {
     Set<Annotation> scopes = null;
     for (Annotation annotation : annotations) {
+      // Reusable is ignored.
+      if (annotation.annotationType() == Reusable.class) {
+        continue;
+      }
       if (annotation.annotationType().getAnnotation(Scope.class) != null) {
         if (scopes == null) {
           scopes = new LinkedHashSet<>();

--- a/reflect/src/main/java/dagger/reflect/Reflection.java
+++ b/reflect/src/main/java/dagger/reflect/Reflection.java
@@ -70,6 +70,7 @@ final class Reflection {
 
   /**
    * Finds scoping annotations that aren't {@link Reusable}.
+   * Reusable is ignored since it is a best effort optimization and isn't a real scoping annotation.
    *
    * @param annotations The set of annotations to parse for scoping annotations.
    * @return All annotations with Scope or an empty set if none are found.

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -82,10 +82,7 @@ final class ReflectiveModuleParser {
       Annotation[] annotations) {
     Annotation scope = findScope(annotations);
     if (scope != null) {
-      if (scope.annotationType().equals(Reusable.class)) {
-        // Do nothing. We're technically not forced to do anything here, as @Reusable is a
-        // best-effort optimization.
-      } else if (!scopeBuilder.annotations.contains(scope)) {
+      if (!scopeBuilder.annotations.contains(scope)) {
         throw new IllegalStateException(); // TODO wrong scope
       } else {
         binding = binding.asScoped();


### PR DESCRIPTION
Not sure if this is the best way to fix this, but it works. This basically makes the Reusable annotation ignored for the purposes of dagger reflect.