### PR TITLE
Make LinkedBinding a Provider

### DIFF
--- a/reflect/src/main/java/dagger/reflect/Binding.java
+++ b/reflect/src/main/java/dagger/reflect/Binding.java
@@ -15,7 +15,7 @@
  */
 package dagger.reflect;
 
-import org.jetbrains.annotations.Nullable;
+import javax.inject.Provider;
 
 interface Binding {
   /**
@@ -36,9 +36,7 @@ interface Binding {
     }
   }
 
-  abstract class LinkedBinding<T> implements Binding {
-    abstract @Nullable T get();
-
+  abstract class LinkedBinding<T> implements Binding, Provider<T> {
     @Override public final LinkedBinding<?> link(Linker linker, Scope scope) {
       return this;
     }

--- a/reflect/src/main/java/dagger/reflect/UnlinkedMapOfProviderBinding.java
+++ b/reflect/src/main/java/dagger/reflect/UnlinkedMapOfProviderBinding.java
@@ -15,8 +15,9 @@ final class UnlinkedMapOfProviderBinding extends UnlinkedBinding {
   @Override public LinkedBinding<Map<Object, Provider<Object>>> link(Linker linker, Scope scope) {
     Map<Object, Provider<Object>> mapOfProviders = new LinkedHashMap<>(entryBindings.size());
     for (Map.Entry<Object, Binding> entryBinding : entryBindings.entrySet()) {
-      LinkedBinding<?> binding = entryBinding.getValue().link(linker, scope);
-      mapOfProviders.put(entryBinding.getKey(), binding::get);
+      LinkedBinding<Object> binding =
+          (LinkedBinding<Object>) entryBinding.getValue().link(linker, scope);
+      mapOfProviders.put(entryBinding.getKey(), binding);
     }
     return new LinkedInstanceBinding<>(mapOfProviders);
   }


### PR DESCRIPTION
This avoids a needless wrapper for map bindings.