### PR TITLE
Fix generating bindings for multibindings with class keys.

### DIFF
--- a/integration-tests/src/main/java/com/example/MultibindingMapClassKey.java
+++ b/integration-tests/src/main/java/com/example/MultibindingMapClassKey.java
@@ -1,0 +1,40 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.ClassKey;
+import dagger.multibindings.IntoMap;
+import java.util.Map;
+
+@Component(modules = MultibindingMapClassKey.Module1.class)
+interface MultibindingMapClassKey {
+
+  Map<Class<?>, I> values();
+
+  @Module
+  abstract class Module1 {
+
+    @Provides
+    @IntoMap
+    @ClassKey(Impl1.class)
+    static I one() {
+      return Impl1.INSTANCE;
+    }
+
+    @Provides
+    @IntoMap
+    @ClassKey(Impl2.class)
+    static I two() {
+      return Impl2.INSTANCE;
+    }
+
+  }
+
+}
+
+interface I {}
+
+enum Impl1 implements I { INSTANCE }
+
+enum Impl2 implements I { INSTANCE }

--- a/integration-tests/src/main/java/com/example/MultibindingMapClassKey.java
+++ b/integration-tests/src/main/java/com/example/MultibindingMapClassKey.java
@@ -28,13 +28,15 @@ interface MultibindingMapClassKey {
     static I two() {
       return Impl2.INSTANCE;
     }
-
   }
-
 }
 
 interface I {}
 
-enum Impl1 implements I { INSTANCE }
+enum Impl1 implements I {
+  INSTANCE
+}
 
-enum Impl2 implements I { INSTANCE }
+enum Impl2 implements I {
+  INSTANCE
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -813,7 +813,8 @@ public final class IntegrationTest {
   @Test
   public void multibindingMapClassKey() {
     MultibindingMapClassKey c = backend.create(MultibindingMapClassKey.class);
-    assertThat(c.values()).containsExactly(Impl1.class, Impl1.INSTANCE, Impl2.class, Impl2.INSTANCE);
+    assertThat(c.values())
+        .containsExactly(Impl1.class, Impl1.INSTANCE, Impl2.class, Impl2.INSTANCE);
   }
 
   @Test

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -811,6 +811,12 @@ public final class IntegrationTest {
   }
 
   @Test
+  public void multibindingMapClassKey() {
+    MultibindingMapClassKey c = backend.create(MultibindingMapClassKey.class);
+    assertThat(c.values()).containsExactly(Impl1.class, Impl1.INSTANCE, Impl2.class, Impl2.INSTANCE);
+  }
+
+  @Test
   public void multibindingMapPrimitiveKey() {
     MultibindingMapPrimitiveKey component = backend.create(MultibindingMapPrimitiveKey.class);
     assertThat(component.values()).containsExactly(1L, "one", 2L, "two");

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -1,6 +1,13 @@
 package dagger.reflect;
 
-import static dagger.reflect.Reflection.*;
+import static dagger.reflect.Reflection.boxIfNecessary;
+import static dagger.reflect.Reflection.findAnnotation;
+import static dagger.reflect.Reflection.findMapKey;
+import static dagger.reflect.Reflection.findQualifier;
+import static dagger.reflect.Reflection.findScope;
+import static dagger.reflect.Reflection.findScopes;
+import static dagger.reflect.Reflection.maybeInstantiate;
+import static dagger.reflect.Reflection.requireAnnotation;
 
 import dagger.Binds;
 import dagger.BindsOptionalOf;

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -1,13 +1,6 @@
 package dagger.reflect;
 
-import static dagger.reflect.Reflection.boxIfNecessary;
-import static dagger.reflect.Reflection.findAnnotation;
-import static dagger.reflect.Reflection.findMapKey;
-import static dagger.reflect.Reflection.findQualifier;
-import static dagger.reflect.Reflection.findScope;
-import static dagger.reflect.Reflection.findScopes;
-import static dagger.reflect.Reflection.maybeInstantiate;
-import static dagger.reflect.Reflection.requireAnnotation;
+import static dagger.reflect.Reflection.*;
 
 import dagger.Binds;
 import dagger.BindsOptionalOf;

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -171,7 +171,7 @@ final class ReflectiveModuleParser {
       }
       Method method = methods[0];
 
-      entryKeyType = boxIfNecessary(method.getReturnType());
+      entryKeyType = boxIfNecessary(method.getGenericReturnType());
       entryKey = Reflection.tryInvoke(entryKeyAnnotation, method);
       if (entryKey == null) {
         throw new AssertionError(); // Not allowed by the Java language specification.


### PR DESCRIPTION
Fixes https://github.com/JakeWharton/dagger-reflect/issues/132

Problem: wrong key for multibindings with class keys. The key has a value of `java.util.Map<java.lang.Class, com.example.I>` when it should be `java.util.Map<java.lang.Class<?>, com.example.I>`.

Solution: fix `ReflectiveModuleParser`: use generic return type when constructing `entryKeyType`.