### PR TITLE
Component binding instance functionality test.

### DIFF
--- a/integration-tests/src/main/java/com/example/ComponentBindingInstance.java
+++ b/integration-tests/src/main/java/com/example/ComponentBindingInstance.java
@@ -1,0 +1,29 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+import javax.inject.Inject;
+
+@Component(modules = ComponentBindingInstance.Module1.class)
+interface ComponentBindingInstance {
+
+  Result result();
+
+  final class Result {
+    public final ComponentBindingInstance foo;
+
+    public Result(ComponentBindingInstance foo) {
+      this.foo = foo;
+    }
+  }
+
+  @Module
+  abstract class Module1 {
+    @Provides
+    static Result foo(ComponentBindingInstance component) {
+      return new Result(component);
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -1345,7 +1345,7 @@ public final class IntegrationTest {
   @Test
   public void componentBindingInstance() {
     ComponentBindingInstance instance = backend.create(ComponentBindingInstance.class);
-    assertThat(instance).isEqualTo(instance.result().foo);
+    assertThat(instance).isSameAs(instance.result().foo);
   }
 
   @Test

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -1343,6 +1343,12 @@ public final class IntegrationTest {
   }
 
   @Test
+  public void componentBindingInstance() {
+    ComponentBindingInstance instance = backend.create(ComponentBindingInstance.class);
+    assertThat(instance).isEqualTo(instance.result().foo);
+  }
+
+  @Test
   @ReflectBug("check not implemented")
   @IgnoreCodegen
   public void componentScopeCycle() {

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -1346,7 +1346,7 @@ public final class IntegrationTest {
   @ReflectBug("check not implemented")
   public void componentBindingInstance() {
     ComponentBindingInstance instance = backend.create(ComponentBindingInstance.class);
-    assertThat(instance).isSameAs(instance.result().foo);
+    assertThat(instance).isSameInstanceAs(instance.result().foo);
   }
 
   @Test

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -1343,6 +1343,7 @@ public final class IntegrationTest {
   }
 
   @Test
+  @ReflectBug("check not implemented")
   public void componentBindingInstance() {
     ComponentBindingInstance instance = backend.create(ComponentBindingInstance.class);
     assertThat(instance).isSameAs(instance.result().foo);


### PR DESCRIPTION
Currently, this PR only adds a test for this functionality. As expected, the `reflect` version fails.

Reference: #136