### PR TITLE
Process included modules when parsing `ContributesAndroidInjector` modules

### DIFF
--- a/integration-tests/android/src/main/java/com/example/ExampleActivity.java
+++ b/integration-tests/android/src/main/java/com/example/ExampleActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.TextView;
 import dagger.Module;
+import dagger.Provides;
 import dagger.android.AndroidInjection;
 import dagger.android.ContributesAndroidInjector;
 import javax.inject.Inject;
@@ -17,6 +18,8 @@ import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
 public final class ExampleActivity extends Activity {
   @Inject String string;
+  @Inject long aLong;
+  @Inject int anInt;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -35,7 +38,27 @@ public final class ExampleActivity extends Activity {
 
   @Module
   static abstract class ExampleActivityModule {
-    @ContributesAndroidInjector
+    @ContributesAndroidInjector(modules = LongModule.class)
     abstract ExampleActivity activity();
   }
+
+  @Module(includes = IntegerModule.class)
+  static class LongModule {
+
+    @Provides
+    static long provideLong() {
+      return 10L;
+    }
+
+  }
+
+  @Module
+  static class IntegerModule {
+
+    @Provides
+    static int provideInt() {
+      return 20;
+    }
+  }
+
 }

--- a/integration-tests/android/src/test/java/com/example/ExampleActivityTest.java
+++ b/integration-tests/android/src/test/java/com/example/ExampleActivityTest.java
@@ -11,11 +11,13 @@ import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class) //
 public final class ExampleActivityTest {
-  @Test public void string() {
+  @Test public void activityInjection() {
     try (ActivityScenario<ExampleActivity> scenario = launch(ExampleActivity.class)) {
       scenario.moveToState(CREATED);
       scenario.onActivity(activity -> {
         assertThat(activity.string).isEqualTo("Hello!");
+        assertThat(activity.aLong).isEqualTo(10L);
+        assertThat(activity.anInt).isEqualTo(20);
       });
     }
   }


### PR DESCRIPTION
`ReflectiveModuleParser` only takes into account the modules directly specified in `ContributesAndroidInjector` annotation and ignores included modules.

Solution: go through the modules recursively and collect all included modules ignoring the duplicates to avoid duplicate bindings.