### PR TITLE
Add test for nullability mismatch.

### DIFF
--- a/integration-tests/src/test/java/com/example/BindsProviderNullabilityMismatch.java
+++ b/integration-tests/src/test/java/com/example/BindsProviderNullabilityMismatch.java
@@ -1,0 +1,20 @@
+package com.example;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import javax.annotation.Nullable;
+
+@Component(modules = BindsProviderNullabilityMismatch.Module1.class)
+interface BindsProviderNullabilityMismatch {
+
+  String string();
+
+  @Module
+  abstract class Module1 {
+    @Provides
+    static @Nullable String string() {
+      return null;
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -61,6 +61,22 @@ public final class IntegrationTest {
   }
 
   @Test
+  @IgnoreCodegen
+  @ReflectBug("check not implemented")
+  public void bindsProviderNullabilityMismatch() {
+    BindsProviderNullabilityMismatch component =
+        backend.create(BindsProviderNullabilityMismatch.class);
+    try {
+      assertThat(component.string()).isNull();
+      fail();
+    } catch (Exception e) {
+      // TODO assert some error message similar to "java.lang.String is not nullable, but is being
+      // provided by @Provides @Nullable String
+      // com.example.BindsProviderNull.Module1.provideString()"
+    }
+  }
+
+  @Test
   public void bindsProviderNull() {
     BindsProviderNull component = backend.create(BindsProviderNull.class);
     assertThat(component.string()).isNull();


### PR DESCRIPTION
When there is a mismatch in nullability between the binding and the request, dagger
throws an exception during compile time. We should throw the same
exception at runtime for Dagger Reflect.

The message should be something like:
```String is not nullable, but is being provided by @Provides @Nullable String com.example.BindsProviderNull.Module1.provideString()```