### PR TITLE
[bugfix] getDistinctTypeHierarchy didn't expand interface hierarchy.

### DIFF
--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -1462,4 +1462,12 @@ public final class IntegrationTest {
               "Scope with annotations [@javax.inject.Singleton()] may not depend on unscoped");
     }
   }
+
+  @Test
+  @IgnoreCodegen
+  public void nestedDependencyInterfaceTest() {
+    String value = "my-value";
+    String result = backend.factory(NestedDependencyInterfaceTest.Factory.class).create(() -> value).value();
+    assertThat(result).isSameInstanceAs(value);
+  }
 }

--- a/integration-tests/src/test/java/com/example/NestedDependencyInterfaceTest.java
+++ b/integration-tests/src/test/java/com/example/NestedDependencyInterfaceTest.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import dagger.Component;
+
+@Component(dependencies = NestedDependencyInterfaceTest.First.class)
+public interface NestedDependencyInterfaceTest {
+  String value();
+
+  @Component.Factory
+  interface Factory {
+    NestedDependencyInterfaceTest create(First dependencies);
+  }
+
+  interface First extends Second {
+
+  }
+
+  interface Second extends Third {
+
+  }
+
+  interface Third {
+    String value();
+  }
+}

--- a/reflect/src/main/java/dagger/reflect/Reflection.java
+++ b/reflect/src/main/java/dagger/reflect/Reflection.java
@@ -207,7 +207,9 @@ final class Reflection {
     Set<Class<?>> types = new LinkedHashSet<>();
     do {
       types.add(target);
-      Collections.addAll(types, target.getInterfaces());
+      for (Class<?> type : target.getInterfaces()) {
+        types.addAll(getDistinctTypeHierarchy(type));
+      }
       target = target.getSuperclass();
     } while (target != null && target != Object.class);
     return types;


### PR DESCRIPTION
Reflection.getDistinctTypeHierarchy now handles the following use case.
```kotlin
interface First extends Second {}
interface Second extends Third {}
interface Third {}
```