### PR TITLE
Add Linker and Scope toString + tests

### DIFF
--- a/integration-tests/src/main/java/com/example/OptionalBindingWrongScope.java
+++ b/integration-tests/src/main/java/com/example/OptionalBindingWrongScope.java
@@ -1,0 +1,42 @@
+package com.example;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import dagger.BindsOptionalOf;
+import dagger.Component;
+import dagger.Module;
+import java.lang.annotation.Retention;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+import javax.inject.Scope;
+import javax.inject.Singleton;
+
+@Singleton
+@Component(modules = OptionalBindingWrongScope.Module1.class)
+public interface OptionalBindingWrongScope {
+  @Qualified
+  Optional<Thing> thing();
+
+  @Module
+  abstract class Module1 {
+    @BindsOptionalOf
+    @Qualified
+    abstract Thing optionalThing();
+  }
+
+  @Qualified // @BindsOptionalOf cannot work with unqualified JIT, so a @Qualifier is needed
+  @Unrelated // mismatched scope (to Singleton) makes putJitBinding return null
+  final class Thing {
+    @Inject
+    Thing() {}
+  }
+
+  @Scope
+  @Retention(RUNTIME)
+  @interface Unrelated {}
+
+  @Qualifier
+  // @Retention(RUNTIME) missing, so that binding is not found
+  @interface Qualified {}
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -245,7 +245,11 @@ public final class IntegrationTest {
       component.thing();
       fail();
     } catch (IllegalStateException e) {
-      // TODO assert some message
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to find binding for key=com.example.JustInTimeWrongScope$Thing"
+                  + " with linker=null");
     }
   }
 
@@ -257,7 +261,11 @@ public final class IntegrationTest {
       component.thing();
       fail();
     } catch (IllegalStateException e) {
-      // TODO assert some message
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to find binding for key=com.example.JustInTimeScopedIntoUnscoped$Thing"
+                  + " with linker=null");
     }
   }
 
@@ -270,7 +278,11 @@ public final class IntegrationTest {
       child.thing();
       fail();
     } catch (IllegalStateException e) {
-      // TODO assert some message
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to find binding for key=com.example.JustInTimeNotScopedInAncestry$Thing"
+                  + " with linker=null");
     }
   }
 

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -159,6 +159,24 @@ public final class IntegrationTest {
   }
 
   @Test
+  @IgnoreCodegen
+  public void optionalBindingWrongScope() {
+    OptionalBindingWrongScope component = backend.create(OptionalBindingWrongScope.class);
+    try {
+      component.thing();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "Unable to find binding for key=com.example.OptionalBindingWrongScope$Thing"
+                  + " with linker=Linker with Scope[@javax.inject.Singleton()]\n"
+                  + " * Requested: java.util.Optional<com.example.OptionalBindingWrongScope$Thing>\n"
+                  + "     from @Optional[com.example.OptionalBindingWrongScope$Module1.optionalThing(…)]\n");
+    }
+  }
+
+  @Test
   public void optionalBindingAbsent() {
     OptionalBindingAbsent component = backend.create(OptionalBindingAbsent.class);
     assertThat(component.string()).isEqualTo(Optional.empty());

--- a/reflect/src/main/java/dagger/reflect/Linker.java
+++ b/reflect/src/main/java/dagger/reflect/Linker.java
@@ -40,6 +40,20 @@ final class Linker {
 
   private RuntimeException failure(Key key, String reason, String cause) {
     StringBuilder builder = new StringBuilder(reason).append(" for ").append(key).append('\n');
+    appendChain(builder);
+    builder.append(" * Requested: ").append(key).append("\n     which ").append(cause).append('.');
+    throw new IllegalStateException(builder.toString());
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("Linker with ").append(scope).append("\n");
+    appendChain(builder);
+    return builder.toString();
+  }
+
+  private void appendChain(StringBuilder builder) {
     for (Map.Entry<Key, Binding> entry : chain.entrySet()) {
       builder
           .append(" * Requested: ")
@@ -48,7 +62,5 @@ final class Linker {
           .append(entry.getValue())
           .append('\n');
     }
-    builder.append(" * Requested: ").append(key).append("\n     which ").append(cause).append('.');
-    throw new IllegalStateException(builder.toString());
   }
 }

--- a/reflect/src/main/java/dagger/reflect/Scope.java
+++ b/reflect/src/main/java/dagger/reflect/Scope.java
@@ -78,7 +78,7 @@ final class Scope {
         throw new IllegalStateException(
             "Unable to find binding for key="
                 + key
-                + " and linker="
+                + " with linker="
                 + linker); // TODO nice error message with scope chain
       }
       return jitBinding;

--- a/reflect/src/main/java/dagger/reflect/Scope.java
+++ b/reflect/src/main/java/dagger/reflect/Scope.java
@@ -35,6 +35,11 @@ final class Scope {
     this.parent = parent;
   }
 
+  @Override
+  public String toString() {
+    return "Scope" + annotations;
+  }
+
   LinkedBinding<?> getBinding(Key key) {
     LinkedBinding<?> binding = findBinding(key, null);
     if (binding != null) {
@@ -76,10 +81,7 @@ final class Scope {
       LinkedBinding<?> jitBinding = putJitBinding(key, linker, jitLookup);
       if (jitBinding == null) {
         throw new IllegalStateException(
-            "Unable to find binding for key="
-                + key
-                + " with linker="
-                + linker); // TODO nice error message with scope chain
+            "Unable to find binding for key=" + key + " with linker=" + linker);
       }
       return jitBinding;
     }


### PR DESCRIPTION
Fixes:
```
reflect\src\main\java\dagger\reflect\Scope.java:84:
warning: [ObjectToString] Linker is final and does not override Object.toString, so converting it to a string will print its identity (e.g. `Linker@ 4488aabb`) instead of useful information
.
            "Unable to find binding for key=" + key + " with linker=" + linker);
                                                                        ^
    (see https://errorprone.info/bugpattern/ObjectToString)
```