### PR TITLE
Add IncompatiblyScopedBindings message

### DIFF
--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -778,7 +778,12 @@ public final class IntegrationTest {
       backend.create(ScopedWrong.class);
       fail();
     } catch (IllegalStateException e) {
-      // TODO some message indicating wrong scope
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "[Dagger/IncompatiblyScopedBindings] "
+                  + "(sub)component scoped with [@javax.inject.Singleton()] may not reference bindings with different scopes:\n"
+                  + "@com.example.ScopedWrong.Unrelated @Provides[com.example.ScopedWrong$Module1.value(…)]");
     }
   }
 

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -99,7 +99,18 @@ final class ReflectiveModuleParser {
     Annotation scope = findScope(annotations);
     if (scope != null) {
       if (!scopeBuilder.annotations.contains(scope)) {
-        throw new IllegalStateException(); // TODO wrong scope
+        throw new IllegalStateException(
+            "[Dagger/IncompatiblyScopedBindings] "
+                // TODO clarify which "(sub)component" failed
+                // (method when UnlinkedAndroidInjectorFactoryBinding is being created)
+                // ([sub]componentClass in when calling ComponentScopeBuilder is calling create)
+                + "(sub)component scoped with "
+                + scopeBuilder.annotations
+                + " may not reference bindings with different scopes:\n"
+                + "@"
+                + scope.annotationType().getCanonicalName()
+                + " "
+                + binding);
       } else {
         binding = binding.asScoped();
       }


### PR DESCRIPTION
Dagger error:
> [Dagger/IncompatiblyScopedBindings] `com.example.ScopedWrong` scoped with `@Singleton` may not reference bindings with different scopes:
> `@Provides @com.example.ScopedWrong.Unrelated Object com.example.ScopedWrong.Module1.value()`

Reflect error:
> [Dagger/IncompatiblyScopedBindings] (sub)component scoped with [`@javax.inject.Singleton()`] may not reference bindings with different scopes:
> `@com.example.ScopedWrong.Unrelated @Provides[com.example.ScopedWrong$Module1.value(…)]`