### PR TITLE
Improve error message for incorrect return types.

### DIFF
--- a/integration-tests/src/test/java/com/example/BindsElementsIntoSetGenericWrongReturn.java
+++ b/integration-tests/src/test/java/com/example/BindsElementsIntoSetGenericWrongReturn.java
@@ -1,0 +1,29 @@
+package com.example;
+
+import dagger.Binds;
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.ElementsIntoSet;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Set;
+
+@Component(modules = BindsElementsIntoSetGenericWrongReturn.Module1.class)
+interface BindsElementsIntoSetGenericWrongReturn {
+  Set<String> strings();
+
+  @Module
+  abstract class Module1 {
+    @Provides
+    static Deque<String> strings() {
+      ArrayDeque<String> strings = new ArrayDeque<>();
+      strings.add("foo");
+      return strings;
+    }
+
+    @Binds
+    @ElementsIntoSet
+    abstract Set<? extends String> setStrings(Deque<String> foo);
+  }
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -108,6 +108,21 @@ public final class IntegrationTest {
   }
 
   @Test
+  @IgnoreCodegen
+  public void bindElementsIntoSetGenericWrongReturn() {
+    try {
+      backend.create(BindsElementsIntoSetGenericWrongReturn.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo(
+              "@Binds methods must return a primitive, an array, a type variable, or a "
+                  + "declared type. Found java.util.Set<? extends java.lang.String>.");
+    }
+  }
+
+  @Test
   public void bindIntoMap() {
     BindsIntoMap component = backend.create(BindsIntoMap.class);
     assertThat(component.strings()).containsExactly("bar", "foo");

--- a/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
+++ b/reflect/src/main/java/dagger/reflect/ReflectiveModuleParser.java
@@ -22,7 +22,9 @@ import dagger.reflect.TypeUtil.ParameterizedTypeImpl;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -140,6 +142,12 @@ final class ReflectiveModuleParser {
     if (Types.getRawType(setKey.type()) != Set.class) {
       throw new IllegalArgumentException(
           "@BindsIntoSet must return Set. Found " + setKey.type() + ".");
+    }
+    if (((ParameterizedType) setKey.type()).getActualTypeArguments()[0] instanceof WildcardType) {
+      throw new IllegalArgumentException(
+          "@Binds methods must return a primitive, an array, a type variable, or a declared type. Found "
+              + setKey.type()
+              + ".");
     }
     scopeBuilder.addBindingElementsIntoSet(setKey, elementsBinding);
   }


### PR DESCRIPTION
This improves the error message for more cases when using `@BindsIntoSet`.

This copies the error message from dagger.

See https://github.com/google/dagger/blob/f9e41bc94701c52c60c534390b59b135444276a4/java/dagger/internal/codegen/BindingElementValidator.java#L101