### PR TITLE
Fix looking up generics when injecting fields in generic subclasses.

### DIFF
--- a/integration-tests/src/main/java/com/example/ProviderMultipleNestedGenericIntoField.java
+++ b/integration-tests/src/main/java/com/example/ProviderMultipleNestedGenericIntoField.java
@@ -1,0 +1,40 @@
+package com.example;
+
+import dagger.Component;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+@Component
+interface ProviderMultipleNestedGenericIntoField {
+  void inject(ThingImpl instance);
+
+  class ThingImpl extends Thing1<Dep1> {
+
+    @Inject Provider<Dep2> dep2;
+  }
+
+  abstract class Thing1<V> extends Thing<V, Dep2> {}
+
+  abstract class Thing<V, T> {
+    @Inject Provider<V> vProvider;
+
+    @Inject Provider<T> tProvider;
+
+    @Inject V value;
+
+    @Inject T t;
+  }
+
+  class Dep1 {
+
+    @Inject
+    Dep1() {}
+  }
+
+  class Dep2 {
+
+    @Inject
+    Dep2() {}
+  }
+}

--- a/integration-tests/src/main/java/com/example/ProviderMultipleNestedGenericIntoField.java
+++ b/integration-tests/src/main/java/com/example/ProviderMultipleNestedGenericIntoField.java
@@ -1,7 +1,6 @@
 package com.example;
 
 import dagger.Component;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -329,6 +329,20 @@ public final class IntegrationTest {
   }
 
   @Test
+  public void providerMultipleNestedGenericIntoField() {
+    ProviderMultipleNestedGenericIntoField c =
+        backend.create(ProviderMultipleNestedGenericIntoField.class);
+    ProviderMultipleNestedGenericIntoField.ThingImpl instance =
+        new ProviderMultipleNestedGenericIntoField.ThingImpl();
+    c.inject(instance);
+    assertThat(instance.vProvider.get()).isNotNull();
+    assertThat(instance.tProvider.get()).isNotNull();
+    assertThat(instance.value).isNotNull();
+    assertThat(instance.t).isNotNull();
+    assertThat(instance.dep2.get()).isNotNull();
+  }
+
+  @Test
   public void providerUnscopedBinding() {
     ProviderUnscopedBinding component = backend.create(ProviderUnscopedBinding.class);
     Provider<String> value = component.value();


### PR DESCRIPTION
This pr adds a test to cover the case when there are @Inject annotated fields with type parameters. Real world example: a class `BaseFragment<P extends Presenter>` with a field `P presenter`.
The fix included is just an ad-hoc solution to highlight the issue and help come up with proper fix.