### PR TITLE
reflect-lint: Support Kotlin annotations with default retention

### DIFF
--- a/reflect-lint/src/test/java/dagger/reflect/lint/java/WrongRetentionDetectorTest.java
+++ b/reflect-lint/src/test/java/dagger/reflect/lint/java/WrongRetentionDetectorTest.java
@@ -97,7 +97,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.java:9: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyQualifier.java:9: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -126,7 +126,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.java:8: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyQualifier.java:8: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(RetentionPolicy.SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -155,7 +155,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.java:8: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyQualifier.java:8: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(value = RetentionPolicy.SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -181,7 +181,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.java:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME). [WrongRetention]\n"
+            "src/foo/MyQualifier.java:6: Error: Java annotations used by Dagger Reflect must be annotated with @Retention(RUNTIME). [WrongRetention]\n"
                 + "public @interface MyQualifier {}\n"
                 + "                  ~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -259,7 +259,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyMapKey.java:9: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyMapKey.java:9: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -285,7 +285,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyMapKey.java:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME). [WrongRetention]\n"
+            "src/foo/MyMapKey.java:6: Error: Java annotations used by Dagger Reflect must be annotated with @Retention(RUNTIME). [WrongRetention]\n"
                 + "public @interface MyMapKey {}\n"
                 + "                  ~~~~~~~~\n"
                 + "1 errors, 0 warnings")

--- a/reflect-lint/src/test/java/dagger/reflect/lint/kotlin/WrongRetentionDetectorTest.java
+++ b/reflect-lint/src/test/java/dagger/reflect/lint/kotlin/WrongRetentionDetectorTest.java
@@ -55,6 +55,23 @@ public final class WrongRetentionDetectorTest {
   }
 
   @Test
+  public void ignoresQualifierAnnotationWithDefaultRetention() {
+    lint()
+        .files(
+            kotlin(
+                "package foo\n"
+                    + "\n"
+                    + "import javax.inject.Qualifier\n"
+                    + "\n"
+                    + "@Qualifier\n"
+                    + "internal annotation class MyQualifier"),
+            QUALIFIER_STUB)
+        .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
+        .run()
+        .expectClean();
+  }
+
+  @Test
   public void ignoresQualifierAnnotationWithRuntimeRetention() {
     lint()
         .files(
@@ -90,7 +107,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.kt:7: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyQualifier.kt:7: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -117,7 +134,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.kt:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyQualifier.kt:6: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(AnnotationRetention.SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -144,7 +161,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyQualifier.kt:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyQualifier.kt:6: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(value = AnnotationRetention.SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -153,31 +170,6 @@ public final class WrongRetentionDetectorTest {
                 + "@@ -6 +6\n"
                 + "- @Retention(value = AnnotationRetention.SOURCE)\n"
                 + "+ @Retention(value = kotlin.annotation.AnnotationRetention.RUNTIME)");
-  }
-
-  @Test
-  public void reportsQualifierAnnotationWithoutRetention() {
-    lint()
-        .files(
-            kotlin(
-                "package foo\n"
-                    + "\n"
-                    + "import javax.inject.Qualifier\n"
-                    + "\n"
-                    + "@Qualifier\n"
-                    + "internal annotation class MyQualifier"),
-            QUALIFIER_STUB)
-        .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
-        .run()
-        .expect(
-            "src/foo/MyQualifier.kt:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME). [WrongRetention]\n"
-                + "internal annotation class MyQualifier\n"
-                + "                          ~~~~~~~~~~~\n"
-                + "1 errors, 0 warnings")
-        .expectFixDiffs(
-            "Fix for src/foo/MyQualifier.kt line 6: Add: `@Retention(RUNTIME)`:\n"
-                + "@@ -5 +5\n"
-                + "+ @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.RUNTIME)");
   }
 
   // MapKey Annotation
@@ -199,6 +191,23 @@ public final class WrongRetentionDetectorTest {
                 "package foo\n"
                     + "\n"
                     + "import foo.bar.MapKey\n"
+                    + "\n"
+                    + "@MapKey\n"
+                    + "internal annotation class MyMapKey"),
+            MAP_KEY_STUB)
+        .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
+        .run()
+        .expectClean();
+  }
+
+  @Test
+  public void ignoresMapKeyAnnotationWithDefaultRetention() {
+    lint()
+        .files(
+            kotlin(
+                "package foo\n"
+                    + "\n"
+                    + "import dagger.MapKey\n"
                     + "\n"
                     + "@MapKey\n"
                     + "internal annotation class MyMapKey"),
@@ -243,7 +252,7 @@ public final class WrongRetentionDetectorTest {
         .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
         .run()
         .expect(
-            "src/foo/MyMapKey.kt:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME) but is @Retention(SOURCE). [WrongRetention]\n"
+            "src/foo/MyMapKey.kt:6: Error: Annotations used by Dagger Reflect must have RUNTIME retention. Found SOURCE. [WrongRetention]\n"
                 + "@Retention(AnnotationRetention.SOURCE)\n"
                 + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
                 + "1 errors, 0 warnings")
@@ -252,31 +261,6 @@ public final class WrongRetentionDetectorTest {
                 + "@@ -6 +6\n"
                 + "- @Retention(AnnotationRetention.SOURCE)\n"
                 + "+ @Retention(kotlin.annotation.AnnotationRetention.RUNTIME)");
-  }
-
-  @Test
-  public void reportsMapKeyAnnotationWithoutRetention() {
-    lint()
-        .files(
-            kotlin(
-                "package foo\n"
-                    + "\n"
-                    + "import dagger.MapKey\n"
-                    + "\n"
-                    + "@MapKey\n"
-                    + "internal annotation class MyMapKey"),
-            MAP_KEY_STUB)
-        .issues(WrongRetentionDetector.ISSUE_WRONG_RETENTION)
-        .run()
-        .expect(
-            "src/foo/MyMapKey.kt:6: Error: Annotation used by Dagger Reflect must be annotated with @Retention(RUNTIME). [WrongRetention]\n"
-                + "internal annotation class MyMapKey\n"
-                + "                          ~~~~~~~~\n"
-                + "1 errors, 0 warnings")
-        .expectFixDiffs(
-            "Fix for src/foo/MyMapKey.kt line 6: Add: `@Retention(RUNTIME)`:\n"
-                + "@@ -5 +5\n"
-                + "+ @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.RUNTIME)");
   }
 
   private static final LintDetectorTest.TestFile MAP_KEY_STUB =


### PR DESCRIPTION
The [default retention for annotations written in Kotlin is RUNTIME](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-retention/-init-.html), but `dagger-reflect-lint` currently flags any Kotlin annotation without an explicit `@Retention(AnnotationRetention.RUNTIME)` as an error.