### PR TITLE
Do not eagerly link providers in a map binding

### DIFF
--- a/integration-tests/upstream/build.gradle
+++ b/integration-tests/upstream/build.gradle
@@ -69,9 +69,6 @@ test.filter {
   // TODO reflect bug! Injecting MembersInjector<T> does not work.
   excludeTest 'dagger.functional.NestedTest', 'nestedBar'
 
-  // TODO reflect bug! Map<Key, Provider<Value>> cycles do not work.
-  excludeTest 'dagger.functional.cycle.CycleTest', 'providerMapIndirectionCycle'
-
   // TODO reflect bug! Subcomponent multibindings propagation does not work.
   excludeTest 'dagger.functional.subcomponent.SubcomponentMultibindingsTest', null
 }

--- a/reflect/src/main/java/dagger/reflect/ScopeBindingProvider.java
+++ b/reflect/src/main/java/dagger/reflect/ScopeBindingProvider.java
@@ -1,0 +1,33 @@
+package dagger.reflect;
+
+import dagger.reflect.Binding.LinkedBinding;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Provider;
+
+final class ScopeBindingProvider<T> implements Provider<T> {
+  private final Scope scope;
+  private final Binding binding;
+  private final AtomicReference<LinkedBinding<T>> linkedRef;
+
+  ScopeBindingProvider(Scope scope, Binding binding) {
+    this.scope = scope;
+    this.binding = binding;
+    this.linkedRef =
+        new AtomicReference<>(
+            binding instanceof LinkedBinding<?> ? (LinkedBinding<T>) binding : null);
+  }
+
+  @Override
+  public T get() {
+    LinkedBinding<T> linked = linkedRef.get();
+    if (linked == null) {
+      linked = (LinkedBinding<T>) binding.link(new Linker(scope), scope);
+
+      LinkedBinding<T> replaced = linkedRef.getAndSet(linked);
+      if (replaced != null) {
+        linked = replaced; // You raced another thread and lost.
+      }
+    }
+    return linked.get();
+  }
+}

--- a/reflect/src/main/java/dagger/reflect/UnlinkedMapOfProviderBinding.java
+++ b/reflect/src/main/java/dagger/reflect/UnlinkedMapOfProviderBinding.java
@@ -16,9 +16,10 @@ final class UnlinkedMapOfProviderBinding extends UnlinkedBinding {
   public LinkedBinding<Map<Object, Provider<Object>>> link(Linker linker, Scope scope) {
     Map<Object, Provider<Object>> mapOfProviders = new LinkedHashMap<>(entryBindings.size());
     for (Map.Entry<Object, Binding> entryBinding : entryBindings.entrySet()) {
-      LinkedBinding<Object> binding =
-          (LinkedBinding<Object>) entryBinding.getValue().link(linker, scope);
-      mapOfProviders.put(entryBinding.getKey(), binding);
+      // Despite linking, this is a Map to Provider<V> which should be lazy. Thus, we capture the
+      // scope and create a Map<K, Provider<V>> instance whose providers are lazy-linked.
+      Provider<Object> provider = new ScopeBindingProvider<>(scope, entryBinding.getValue());
+      mapOfProviders.put(entryBinding.getKey(), provider);
     }
     return new LinkedInstanceBinding<>(mapOfProviders);
   }


### PR DESCRIPTION
Previously we linked them when the map was linked. But we only need the map to be linked to capture the scope. The map's providers of values should still be late-linked upon first access.

Closes #175. cc @alexjlockwood