### PR TITLE
Fix injection when using generics

### DIFF
--- a/integration-tests/src/main/java/com/example/MemberInjectionGenericInjector.java
+++ b/integration-tests/src/main/java/com/example/MemberInjectionGenericInjector.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import javax.inject.Inject;
+
+@Component
+public interface MemberInjectionGenericInjector
+    extends Injector<MemberInjectionGenericInjector.Target> {
+
+  @Component.Factory
+  interface Factory {
+    MemberInjectionGenericInjector create(@BindsInstance String one);
+  }
+
+  class Target {
+    @Inject String one;
+  }
+}
+
+interface Injector<T> {
+  void inject(T target);
+}

--- a/integration-tests/src/test/java/com/example/IntegrationTest.java
+++ b/integration-tests/src/test/java/com/example/IntegrationTest.java
@@ -637,6 +637,16 @@ public final class IntegrationTest {
   }
 
   @Test
+  public void memberInjectionGenericInjector() {
+    final String expectedStr = "expected";
+    MemberInjectionGenericInjector component =
+        backend.factory(MemberInjectionGenericInjector.Factory.class).create(expectedStr);
+    MemberInjectionGenericInjector.Target target = new MemberInjectionGenericInjector.Target();
+    component.inject(target);
+    assertThat(target.one).isEqualTo(expectedStr);
+  }
+
+  @Test
   public void memberInjectionEmptyAbstractClass() {
     MemberInjectionEmptyAbstract component = backend.create(MemberInjectionEmptyAbstract.class);
     MemberInjectionEmptyAbstract.Target target = new MemberInjectionEmptyAbstract.Target() {};


### PR DESCRIPTION
Currently, dagger-reflect doesn't work with injectors interfaces relying on generics, such as:

```kotlin
interface Injector<T> {
    fun inject(instance: T)
}

@Component
interface MainActivityComponent : Injector<MainActivity>
```

This PR would fix this issue.